### PR TITLE
#18 <Payment> 단건 Read 조회 기능 구현

### DIFF
--- a/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/dto/exception/PaymentNotFoundException.java
+++ b/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/dto/exception/PaymentNotFoundException.java
@@ -1,0 +1,7 @@
+package com.taken_seat.payment_service.application.dto.exception;
+
+public class PaymentNotFoundException extends RuntimeException {
+	public PaymentNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/dto/response/PaymentDetailResDto.java
+++ b/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/dto/response/PaymentDetailResDto.java
@@ -34,6 +34,7 @@ public class PaymentDetailResDto {
 	public static PaymentDetailResDto toResponse(Payment payment) {
 		return PaymentDetailResDto.builder()
 			.paymentId(payment.getId())
+			.price(payment.getPrice())
 			.bookingId(payment.getBookingId())
 			.paymentStatus(payment.getPaymentStatus())
 			.approvedAt(payment.getApprovedAt())

--- a/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/dto/response/PaymentDetailResDto.java
+++ b/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/dto/response/PaymentDetailResDto.java
@@ -1,0 +1,45 @@
+package com.taken_seat.payment_service.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.taken_seat.payment_service.domain.enums.PaymentStatus;
+import com.taken_seat.payment_service.domain.model.Payment;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentDetailResDto {
+
+	private UUID paymentId;
+
+	private UUID bookingId;
+
+	private Integer price;
+
+	private PaymentStatus paymentStatus;
+
+	private LocalDateTime approvedAt;
+
+	private Integer refundAmount;
+
+	private LocalDateTime refundRequestedAt;
+
+	public static PaymentDetailResDto toResponse(Payment payment) {
+		return PaymentDetailResDto.builder()
+			.paymentId(payment.getId())
+			.bookingId(payment.getBookingId())
+			.paymentStatus(payment.getPaymentStatus())
+			.approvedAt(payment.getApprovedAt())
+			.refundAmount(payment.getRefundAmount())
+			.refundRequestedAt(payment.getRefundRequestedAt())
+			.build();
+	}
+
+}

--- a/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/service/PaymentService.java
+++ b/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/service/PaymentService.java
@@ -4,8 +4,11 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.taken_seat.payment_service.application.dto.exception.PaymentNotFoundException;
 import com.taken_seat.payment_service.application.dto.request.PaymentRegisterReqDto;
+import com.taken_seat.payment_service.application.dto.response.PaymentDetailResDto;
 import com.taken_seat.payment_service.application.dto.response.PaymentRegisterResDto;
 import com.taken_seat.payment_service.domain.enums.PaymentStatus;
 import com.taken_seat.payment_service.domain.model.Payment;
@@ -19,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class PaymentService {
 
 	private final PaymentRepository paymentRepository;
@@ -67,5 +71,14 @@ public class PaymentService {
 		);
 
 		return PaymentRegisterResDto.toResponse(payment);
+	}
+
+	@Transactional(readOnly = true)
+	public PaymentDetailResDto getPaymentDetail(UUID id) {
+
+		Payment payment = paymentRepository.findByIdAndDeletedAtIsNull(id)
+			.orElseThrow(() -> new PaymentNotFoundException("해당 ID 에 대한 결제 정보를 찾을 수 없습니다 : " + id));
+
+		return PaymentDetailResDto.toResponse(payment);
 	}
 }

--- a/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/domain/repository/PaymentRepository.java
+++ b/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/domain/repository/PaymentRepository.java
@@ -1,5 +1,8 @@
 package com.taken_seat.payment_service.domain.repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.stereotype.Repository;
 
 import com.taken_seat.payment_service.domain.model.Payment;
@@ -8,5 +11,7 @@ import com.taken_seat.payment_service.domain.model.Payment;
 public interface PaymentRepository {
 
 	Payment save(Payment payment);
+
+	Optional<Payment> findByIdAndDeletedAtIsNull(UUID id);
 
 }

--- a/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/presentation/controller/PaymentController.java
+++ b/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/presentation/controller/PaymentController.java
@@ -2,11 +2,14 @@ package com.taken_seat.payment_service.presentation.controller;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,6 +39,12 @@ public class PaymentController {
 
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(paymentService.registerPayment(paymentRegisterReqDto));
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<?> getPaymentDetail(@PathVariable("id") UUID id) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(paymentService.getPaymentDetail(id));
 	}
 
 	private List<Map<String, String>> convertBindingErrors(BindingResult bindingResult) {


### PR DESCRIPTION
## 개요
결제에 대한 단건 조회 기능 구현 

## 작업 내용
### 변경 사항

- `/api/v1/payments/{id}` 경로의 `GET` 요청을 처리
- payment UUID로 조회
- PaymentNotFoundException 예외처리 구현
- PaymentDetailResDto 단건 조회 반환 DTO 구현
- 단위 테스트 작성
### 변경 이유

### 추가 설명
- deleteAt이 null인 데이터만 조하한다.
- uuid로 조회를 실패할 경우 PaymentNotFoundException 발생
- 성공 / 실패 단위 테스트 작성 완료
## 리뷰 요구사항

#### 연관된 이슈
closed #18 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
