### PR TITLE
#45 Auth 유저 조회기능

### DIFF
--- a/com.taken_seat.auth-service/build.gradle
+++ b/com.taken_seat.auth-service/build.gradle
@@ -36,6 +36,13 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.kafka:spring-kafka'
 
+	//queryDSL 의존성
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	implementation 'com.google.code.findbugs:jsr305:3.0.2'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	// db
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/com.taken_seat.auth-service/build.gradle
+++ b/com.taken_seat.auth-service/build.gradle
@@ -27,6 +27,20 @@ ext {
 	set('springCloudVersion', "2024.0.1")
 }
 
+def querydslDir = "$buildDir/generated/sources/annotationProcessor/java/main"
+
+sourceSets {
+	main {
+		java {
+			srcDirs += querydslDir
+		}
+	}
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/application/dto/PageResponseDto.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/application/dto/PageResponseDto.java
@@ -1,0 +1,32 @@
+package com.taken_seat.auth_service.application.dto;
+
+import lombok.*;
+import org.springframework.data.domain.Page;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(access = AccessLevel.PRIVATE)
+public class PageResponseDto<T> implements Serializable {
+
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+
+    public static <T> PageResponseDto<T> of(Page<T> page) {
+        return PageResponseDto.<T>builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .build();
+    }
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/application/dto/user/UserInfoResponseDto.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/application/dto/user/UserInfoResponseDto.java
@@ -1,0 +1,48 @@
+package com.taken_seat.auth_service.application.dto.user;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.taken_seat.auth_service.application.dto.PageResponseDto;
+import com.taken_seat.auth_service.domain.entity.user.User;
+import com.taken_seat.auth_service.domain.entity.user.UserCoupon;
+import com.taken_seat.auth_service.domain.vo.Role;
+import lombok.*;
+import org.springframework.data.domain.Page;
+
+import java.util.UUID;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 필드 제외
+public class UserInfoResponseDto {
+
+    private UUID userId;
+    private String username;
+    private String email;
+    private String phone;
+    private Role role;
+    private PageResponseDto<UUID> userCoupons;
+
+    public static UserInfoResponseDto of(User user) {
+        return UserInfoResponseDto.builder()
+                .userId(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .phone(user.getPhone())
+                .role(user.getRole())
+                .build();
+    }
+
+    public static UserInfoResponseDto listOf(User user, Page<UserCoupon> userCoupons) {
+        PageResponseDto<UUID> couponsPage = PageResponseDto.of(userCoupons.map(UserCoupon::getCouponId));
+        return UserInfoResponseDto.builder()
+                .userId(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .phone(user.getPhone())
+                .role(user.getRole())
+                .userCoupons(couponsPage)
+                .build();
+    }
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/application/dto/user/UserInfoResponseDto.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/application/dto/user/UserInfoResponseDto.java
@@ -2,12 +2,14 @@ package com.taken_seat.auth_service.application.dto.user;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.taken_seat.auth_service.application.dto.PageResponseDto;
+import com.taken_seat.auth_service.domain.entity.mileage.Mileage;
 import com.taken_seat.auth_service.domain.entity.user.User;
 import com.taken_seat.auth_service.domain.entity.user.UserCoupon;
 import com.taken_seat.auth_service.domain.vo.Role;
 import lombok.*;
 import org.springframework.data.domain.Page;
 
+import java.util.Comparator;
 import java.util.UUID;
 
 @Getter
@@ -22,6 +24,7 @@ public class UserInfoResponseDto {
     private String email;
     private String phone;
     private Role role;
+    private Integer mileage;
     private PageResponseDto<UUID> userCoupons;
 
     public static UserInfoResponseDto of(User user) {
@@ -42,6 +45,10 @@ public class UserInfoResponseDto {
                 .email(user.getEmail())
                 .phone(user.getPhone())
                 .role(user.getRole())
+                .mileage(user.getMileages().stream()
+                        .max(Comparator.comparing(Mileage::getUpdatedAt))
+                        .map(Mileage::getCount)
+                .orElse(0))
                 .userCoupons(couponsPage)
                 .build();
     }

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/application/service/user/UserService.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/application/service/user/UserService.java
@@ -1,0 +1,44 @@
+package com.taken_seat.auth_service.application.service.user;
+
+import com.taken_seat.auth_service.application.dto.user.UserInfoResponseDto;
+import com.taken_seat.auth_service.domain.entity.user.User;
+import com.taken_seat.auth_service.domain.entity.user.UserCoupon;
+import com.taken_seat.auth_service.domain.repository.user.UserRepository;
+import com.taken_seat.auth_service.domain.repository.userCoupon.UserCouponRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class UserService {
+    
+    private final UserRepository userRepository;
+    private final UserCouponRepository userCouponRepository;
+    
+    public UserService(UserRepository userRepository, UserCouponRepository userCouponRepository) {
+        this.userRepository = userRepository;
+        this.userCouponRepository = userCouponRepository;
+    }
+
+    public UserInfoResponseDto getUser(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return UserInfoResponseDto.of(user);
+    }
+
+    public UserInfoResponseDto getUserDetails(UUID userId, int page, int size) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<UserCoupon> userCoupons = userCouponRepository.findByUserIdAndIsActiveFalse(user.getId(), pageable);
+
+        return UserInfoResponseDto.listOf(user, userCoupons);
+    }
+
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/application/service/user/UserService.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/application/service/user/UserService.java
@@ -1,16 +1,17 @@
 package com.taken_seat.auth_service.application.service.user;
 
+import com.taken_seat.auth_service.application.dto.PageResponseDto;
 import com.taken_seat.auth_service.application.dto.user.UserInfoResponseDto;
 import com.taken_seat.auth_service.domain.entity.user.User;
 import com.taken_seat.auth_service.domain.entity.user.UserCoupon;
+import com.taken_seat.auth_service.domain.repository.user.UserQueryRepository;
 import com.taken_seat.auth_service.domain.repository.user.UserRepository;
 import com.taken_seat.auth_service.domain.repository.userCoupon.UserCouponRepository;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -18,12 +19,15 @@ public class UserService {
     
     private final UserRepository userRepository;
     private final UserCouponRepository userCouponRepository;
-    
-    public UserService(UserRepository userRepository, UserCouponRepository userCouponRepository) {
+    private final UserQueryRepository userQueryRepository;
+
+    public UserService(UserRepository userRepository, UserCouponRepository userCouponRepository, UserQueryRepository userQueryRepository) {
         this.userRepository = userRepository;
         this.userCouponRepository = userCouponRepository;
+        this.userQueryRepository = userQueryRepository;
     }
 
+    @Transactional(readOnly = true)
     public UserInfoResponseDto getUser(UUID userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
@@ -31,6 +35,7 @@ public class UserService {
         return UserInfoResponseDto.of(user);
     }
 
+    @Transactional(readOnly = true)
     public UserInfoResponseDto getUserDetails(UUID userId, int page, int size) {
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
@@ -41,4 +46,17 @@ public class UserService {
         return UserInfoResponseDto.listOf(user, userCoupons);
     }
 
+    @Transactional(readOnly = true)
+    public PageResponseDto<UserInfoResponseDto> searchUser(String q, String role, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<User> userInfos = userQueryRepository.findAllByDeletedAtIsNull(q, role, pageable);
+
+        Page<UserInfoResponseDto> userInfoPage = userInfos.map(user -> {
+            List<UserCoupon> coupons = user.getUserCoupons();
+            Page<UserCoupon> userCouponsPage = new PageImpl<>(coupons, PageRequest.of(page, size), coupons.size());
+            return UserInfoResponseDto.listOf(user, userCouponsPage);
+        });
+
+        return PageResponseDto.of(userInfoPage);
+    }
 }

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/entity/mileage/Mileage.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/entity/mileage/Mileage.java
@@ -1,0 +1,67 @@
+package com.taken_seat.auth_service.domain.entity.mileage;
+
+import com.taken_seat.auth_service.domain.entity.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "p_mileage")
+public class Mileage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "count", nullable = false)
+    private Integer count = 0;
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @Column(updatable = false)
+    private UUID createdBy;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime updatedAt;
+
+    @Column
+    private UUID updatedBy;
+
+    @Column
+    private LocalDateTime deletedAt;
+
+    @Column
+    private UUID deletedBy;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime time = LocalDateTime.now();
+        this.createdAt = time;
+        this.updatedAt = time;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // ======================================= 테이블 연관 관게 =======================================
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
+    private User user;
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/entity/user/User.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/entity/user/User.java
@@ -7,6 +7,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -73,6 +75,9 @@ public class User {
     }
 
 // ======================================= 테이블 연관 관게 =======================================
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<UserCoupon> userCoupons = new ArrayList<>();
 
     public static User create(String username, String email, String phone, String password, Role role, UUID createdBy) {
         return User.builder()

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/entity/user/User.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/entity/user/User.java
@@ -1,5 +1,6 @@
 package com.taken_seat.auth_service.domain.entity.user;
 
+import com.taken_seat.auth_service.domain.entity.mileage.Mileage;
 import com.taken_seat.auth_service.domain.vo.Role;
 import jakarta.persistence.*;
 import lombok.*;
@@ -78,6 +79,9 @@ public class User {
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<UserCoupon> userCoupons = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<Mileage> mileages = new ArrayList<>();
 
     public static User create(String username, String email, String phone, String password, Role role, UUID createdBy) {
         return User.builder()

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/entity/user/UserCoupon.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/entity/user/UserCoupon.java
@@ -1,0 +1,36 @@
+package com.taken_seat.auth_service.domain.entity.user;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "p_user_coupon")
+@IdClass(UserCouponId.class)
+public class UserCoupon {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
+    private User user;
+
+    @Id
+    @Column(name = "coupon_id")
+    private UUID couponId;
+
+    @Column(name = "is_active")
+    private boolean isActive = true;
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/entity/user/UserCouponId.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/entity/user/UserCouponId.java
@@ -1,0 +1,18 @@
+package com.taken_seat.auth_service.domain.entity.user;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+class UserCouponId implements Serializable {
+
+    private UUID user;
+    private UUID couponId;
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/repository/user/UserQueryRepository.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/repository/user/UserQueryRepository.java
@@ -1,0 +1,10 @@
+package com.taken_seat.auth_service.domain.repository.user;
+
+import com.taken_seat.auth_service.domain.entity.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserQueryRepository {
+
+    Page<User> findAllByDeletedAtIsNull(String q, String role, Pageable pageable);
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/repository/user/UserRepository.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/repository/user/UserRepository.java
@@ -4,6 +4,7 @@ import com.taken_seat.auth_service.domain.entity.user.User;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 public interface UserRepository {
@@ -11,4 +12,6 @@ public interface UserRepository {
     Optional<User> findByEmail(String email);
 
     User save(User user);
+
+    Optional<User> findById(UUID userId);
 }

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/repository/userCoupon/UserCouponRepository.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/domain/repository/userCoupon/UserCouponRepository.java
@@ -1,0 +1,14 @@
+package com.taken_seat.auth_service.domain.repository.userCoupon;
+
+import com.taken_seat.auth_service.domain.entity.user.UserCoupon;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface UserCouponRepository {
+
+    Page<UserCoupon> findByUserIdAndIsActiveFalse(UUID id, Pageable pageable);
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/config/QuerydslConfig.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package com.taken_seat.auth_service.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/persistence/user/UserQueryRepositoryImpl.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/persistence/user/UserQueryRepositoryImpl.java
@@ -5,7 +5,6 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.taken_seat.auth_service.domain.entity.mileage.QMileage;
 import com.taken_seat.auth_service.domain.entity.user.QUser;
-import com.taken_seat.auth_service.domain.entity.user.QUserCoupon;
 import com.taken_seat.auth_service.domain.entity.user.User;
 import com.taken_seat.auth_service.domain.repository.user.UserQueryRepository;
 import com.taken_seat.auth_service.domain.vo.Role;
@@ -28,7 +27,6 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
     public Page<User> findAllByDeletedAtIsNull(String q, String role, Pageable pageable) {
         QUser user = QUser.user;
         QMileage mileage = QMileage.mileage;
-        QUserCoupon userCoupon = QUserCoupon.userCoupon;
 
         // 컨텐츠 조회
         List<User> content = jpaQueryFactory
@@ -67,7 +65,7 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
     // 검색어 조건
     private BooleanExpression searchCondition(String q, QUser user) {
         return StringUtils.hasText(q) ?
-                user.username.containsIgnoreCase(q).or(user.email.containsIgnoreCase(q)) : null;
+                user.username.containsIgnoreCase(q) : null;
     }
 
     // 역할 조건

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/persistence/user/UserQueryRepositoryImpl.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/persistence/user/UserQueryRepositoryImpl.java
@@ -1,0 +1,92 @@
+package com.taken_seat.auth_service.infrastructure.persistence.user;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.taken_seat.auth_service.domain.entity.mileage.QMileage;
+import com.taken_seat.auth_service.domain.entity.user.QUser;
+import com.taken_seat.auth_service.domain.entity.user.QUserCoupon;
+import com.taken_seat.auth_service.domain.entity.user.User;
+import com.taken_seat.auth_service.domain.repository.user.UserQueryRepository;
+import com.taken_seat.auth_service.domain.vo.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<User> findAllByDeletedAtIsNull(String q, String role, Pageable pageable) {
+        QUser user = QUser.user;
+        QMileage mileage = QMileage.mileage;
+        QUserCoupon userCoupon = QUserCoupon.userCoupon;
+
+        // 컨텐츠 조회
+        List<User> content = jpaQueryFactory
+                .selectFrom(user)
+                .distinct() // 중복 제거
+                .leftJoin(user.mileages, mileage).fetchJoin()
+                .where(
+                        isNotDeleted(user),
+                        searchCondition(q, user), // 유저 이름 또는 이메일로 검색
+                        roleEq(role, user), // 유저 권한 검색
+                        isLatestMileage(user, mileage) // 서브 쿼리
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 카운트 조회
+        Long count = jpaQueryFactory
+                .select(user.countDistinct())
+                .from(user)
+                .where(
+                        isNotDeleted(user),
+                        searchCondition(q, user),
+                        roleEq(role, user)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, count != null ? count : 0);
+    }
+
+    // 삭제되지 않은 사용자 조건
+    private BooleanExpression isNotDeleted(QUser user) {
+        return user.deletedAt.isNull();
+    }
+
+    // 검색어 조건
+    private BooleanExpression searchCondition(String q, QUser user) {
+        return StringUtils.hasText(q) ?
+                user.username.containsIgnoreCase(q).or(user.email.containsIgnoreCase(q)) : null;
+    }
+
+    // 역할 조건
+    private BooleanExpression roleEq(String role, QUser user) {
+        return StringUtils.hasText(role) ?
+                user.role.eq(Role.valueOf(role)) : null;
+    }
+
+    // 최신 마일리지 조건
+    private BooleanExpression isLatestMileage(QUser user, QMileage mileage) {
+        QMileage subMileage = new QMileage("subMileage");
+
+        return mileage.id.in(
+                JPAExpressions
+                        .select(subMileage.id)
+                        .from(subMileage)
+                        .where(subMileage.user.eq(user))
+                        .orderBy(subMileage.updatedAt.desc())
+                        .limit(1)
+        ).or(mileage.isNull());
+    }
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/persistence/userCoupon/UserCouponRepositoryImpl.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/persistence/userCoupon/UserCouponRepositoryImpl.java
@@ -1,0 +1,10 @@
+package com.taken_seat.auth_service.infrastructure.persistence.userCoupon;
+
+import com.taken_seat.auth_service.domain.entity.user.UserCoupon;
+import com.taken_seat.auth_service.domain.repository.userCoupon.UserCouponRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserCouponRepositoryImpl extends JpaRepository<UserCoupon, UUID> , UserCouponRepository {
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/presentation/controller/user/UserController.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/presentation/controller/user/UserController.java
@@ -1,0 +1,37 @@
+package com.taken_seat.auth_service.presentation.controller.user;
+
+import com.taken_seat.auth_service.application.dto.user.UserInfoResponseDto;
+import com.taken_seat.auth_service.application.service.user.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@Slf4j
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserInfoResponseDto> getUser(@PathVariable UUID userId) {
+        UserInfoResponseDto userinfo = userService.getUser(userId);
+
+        return ResponseEntity.ok(userinfo);
+    }
+
+    @GetMapping("/details/{userId}")
+    public ResponseEntity<UserInfoResponseDto> getUserDetails(@PathVariable UUID userId,
+                                                              @RequestParam(defaultValue = "0") int page,
+                                                              @RequestParam(defaultValue = "10") int size) {
+        UserInfoResponseDto userinfo = userService.getUserDetails(userId, page, size);
+
+        return ResponseEntity.ok(userinfo);
+    }
+}

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/presentation/controller/user/UserController.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/presentation/controller/user/UserController.java
@@ -1,9 +1,11 @@
 package com.taken_seat.auth_service.presentation.controller.user;
 
+import com.taken_seat.auth_service.application.dto.PageResponseDto;
 import com.taken_seat.auth_service.application.dto.user.UserInfoResponseDto;
 import com.taken_seat.auth_service.application.service.user.UserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -21,17 +23,27 @@ public class UserController {
 
     @GetMapping("/{userId}")
     public ResponseEntity<UserInfoResponseDto> getUser(@PathVariable UUID userId) {
-        UserInfoResponseDto userinfo = userService.getUser(userId);
+        UserInfoResponseDto userInfo = userService.getUser(userId);
 
-        return ResponseEntity.ok(userinfo);
+        return ResponseEntity.ok(userInfo);
     }
 
     @GetMapping("/details/{userId}")
     public ResponseEntity<UserInfoResponseDto> getUserDetails(@PathVariable UUID userId,
                                                               @RequestParam(defaultValue = "0") int page,
                                                               @RequestParam(defaultValue = "10") int size) {
-        UserInfoResponseDto userinfo = userService.getUserDetails(userId, page, size);
+        UserInfoResponseDto userInfo = userService.getUserDetails(userId, page, size);
 
-        return ResponseEntity.ok(userinfo);
+        return ResponseEntity.ok(userInfo);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<PageResponseDto<UserInfoResponseDto>> searchUser(@RequestParam(required = false) String q,
+                                                               @RequestParam(required = false) String role,
+                                                               @RequestParam(defaultValue = "0") int page,
+                                                               @RequestParam(defaultValue = "10") int size){
+        PageResponseDto<UserInfoResponseDto> userInfo = userService.searchUser(q, role, page, size);
+
+        return ResponseEntity.ok(userInfo);
     }
 }


### PR DESCRIPTION
## 개요
#45 Auth 유저 조회기능

## 작업 내용
### 변경 사항
- 유저의 기본 정보를 조회할 수 있는 기능
- 유저의 기본 정보와 보유하고 있는 쿠폰 정보를 조회할 수 있는 기능
- 쿠폰은 page처리 했습니다.
- 쿠폰 발급시 저장할 수 있는 UserCoupon 엔티티와 복합키 설정을 하였습니다.
- 임시로 엔티티 수명주기를 설정하였습니다.
- 전체 조회 기능을 구현했습니다. 
- 사용자의 이름 또는 권한을 파라미터에 추가해서 검색할 수 있습니다.
- 마일리지는 가장 최근에 업데이트 된 상태를 가져옵니다.

### 변경 이유

### 추가 설명
추가적인 검증 로직은 향후 개발 예정입니다..!

## 리뷰 요구사항

#### 연관된 이슈
closed #45 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
