### PR TITLE
#58 Auth 로그인 시 헤더에 token값 담아서 반환

### DIFF
--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/util/JwtUtil.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/util/JwtUtil.java
@@ -50,7 +50,7 @@ public class JwtUtil {
     }
 
     public String createToken(User userinfo){
-        return BEARER_PREFIX + Jwts.builder()
+        return Jwts.builder()
                 .setSubject(String.valueOf(userinfo.getId()))
                 .claim("email", userinfo.getEmail())
                 .claim("role", userinfo.getRole())
@@ -63,7 +63,7 @@ public class JwtUtil {
 
 
     public String createRefreshToken(UUID userId){
-        return BEARER_PREFIX + Jwts.builder()
+        return Jwts.builder()
                 .claim("userId", userId.toString())
                 .setExpiration(new Date(System.currentTimeMillis()+refreshExpiration))
                 .setIssuedAt(new Date(System.currentTimeMillis()))

--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/presentation/controller/auth/AuthController.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/presentation/controller/auth/AuthController.java
@@ -37,6 +37,7 @@ public class AuthController {
         AuthLoginResponseDto userinfo = authService.login(requestDto.toDto());
 
         return ResponseEntity.ok()
+                .header("Authorization", userinfo.getAccessToken())
                 .body(userinfo);
     }
 }

--- a/com.taken_seat.gateway-service/src/main/java/com/taken_seat/gateway_service/util/JwtUtil.java
+++ b/com.taken_seat.gateway-service/src/main/java/com/taken_seat/gateway_service/util/JwtUtil.java
@@ -28,10 +28,10 @@ public class JwtUtil {
 
     public String extractToken(ServerWebExchange exchange) {
         String header = exchange.getRequest().getHeaders().getFirst("Authorization");
-        if (header != null || header.startsWith("Bearer ")) {
-            return header.substring(7);
+        if (header == null || !header.startsWith("Bearer ")) {
+            return null;
         }
-        return null;
+        return header.substring(7);
     }
 
     public boolean validateToken(String token) {


### PR DESCRIPTION
- 로그인 시 token 값을 헤더에 담아서 반환합니다

## 개요
#45 Auth 유저 조회기능

## 작업 내용
### 변경 사항
- 로그인 시 token 값을 헤더에 담아서 반환합니다

### 변경 이유
- 기존 body에만 token을 담아서 보내는 흐름에서 
- 헤더에 token을 담아서 다른 서비스에서 헤더에 담긴 token을 사용할 수 있게 수정

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
