### PR TITLE
#34 <Performance> 공연 삭제 API 구현

### DIFF
--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PerformanceService {
 
 	private final PerformanceRepository performanceRepository;
-	
+
 	@Transactional
 	public CreateResponseDto create(CreateRequestDto request) {
 
@@ -37,7 +37,7 @@ public class PerformanceService {
 	public void delete(UUID id, UUID deletedBy) {
 
 		if (id == null) {
-			throw new IllegalArgumentException("삭제할 수 없는 아이디입니다");
+			throw new IllegalArgumentException("공연 ID는 null일 수 없습니다.");
 		}
 
 		performanceRepository.deleteById(id, deletedBy);

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
@@ -2,7 +2,10 @@ package com.taken_seat.performance_service.performance.application.service;
 
 import static com.taken_seat.performance_service.performance.application.dto.mapper.ResponseMapper.*;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
@@ -18,7 +21,8 @@ import lombok.extern.slf4j.Slf4j;
 public class PerformanceService {
 
 	private final PerformanceRepository performanceRepository;
-
+	
+	@Transactional
 	public CreateResponseDto create(CreateRequestDto request) {
 
 		Performance performance = Performance.create(request);
@@ -27,5 +31,15 @@ public class PerformanceService {
 
 		return createToDto(saved);
 
+	}
+
+	@Transactional
+	public void delete(UUID id, UUID deletedBy) {
+
+		if (id == null) {
+			throw new IllegalArgumentException("삭제할 수 없는 아이디입니다");
+		}
+
+		performanceRepository.deleteById(id, deletedBy);
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
@@ -60,6 +60,12 @@ public class Performance {
 
 	private String discountInfo;
 
+	@Column(name = "deleted_by")
+	private UUID deletedBy;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
 	@OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Builder.Default
 	private List<PerformanceSchedule> schedules = new ArrayList<>();
@@ -109,5 +115,11 @@ public class Performance {
 
 		performance.getSchedules().addAll(schedules);
 		return performance;
+	}
+
+	public void softDelete(UUID userId) {
+
+		this.deletedBy = userId;
+		this.deletedAt = LocalDateTime.now();
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/repository/PerformanceRepository.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/repository/PerformanceRepository.java
@@ -1,8 +1,12 @@
 package com.taken_seat.performance_service.performance.domain.repository;
 
+import java.util.UUID;
+
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 
 public interface PerformanceRepository {
 
 	Performance save(Performance performance);
+
+	void deleteById(UUID id, UUID deletedBy);
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceJpaRepository.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceJpaRepository.java
@@ -1,5 +1,6 @@
 package com.taken_seat.performance_service.performance.infrastructure.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,5 @@ import com.taken_seat.performance_service.performance.domain.model.Performance;
 
 public interface PerformanceJpaRepository extends JpaRepository<Performance, UUID> {
 
+	Optional<Performance> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceRepositoryImpl.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.taken_seat.performance_service.performance.infrastructure.repository;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Repository;
 
 import com.taken_seat.performance_service.performance.domain.model.Performance;
@@ -16,5 +18,14 @@ public class PerformanceRepositoryImpl implements PerformanceRepository {
 	@Override
 	public Performance save(Performance performance) {
 		return performanceJpaRepository.save(performance);
+	}
+
+	@Override
+	public void deleteById(UUID id, UUID deletedBy) {
+
+		Performance performance = performanceJpaRepository.findByIdAndDeletedAtIsNull(id)
+			.orElseThrow(() -> new IllegalArgumentException("이미 삭제된 아이디입니다"));
+
+		performance.softDelete(deletedBy);
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
@@ -1,10 +1,15 @@
 package com.taken_seat.performance_service.performance.presentation.controller;
 
+import java.util.UUID;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
@@ -32,5 +37,17 @@ public class PerformanceController {
 		CreateResponseDto response = performanceService.create(request);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 
+	}
+
+	/**
+	 * Security 완성 후
+	 * @RequestParam UUID deletedBy -> @AuthenticationPrincipal CustomUserDetails principal 로 수정 예정
+	 */
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Void> delete(@PathVariable("id") UUID id, @RequestParam UUID deletedBy) {
+
+		performanceService.delete(id, deletedBy);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/model/PerformanceHall.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/model/PerformanceHall.java
@@ -42,5 +42,6 @@ public class PerformanceHall {
 	private String description;
 
 	@OneToMany(mappedBy = "performanceHall", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
 	private List<Seat> seats = new ArrayList<>();
 }

--- a/com.taken_seat.performance-service/src/test/java/com/taken_seat/performance_service/performance/application/service/PerformanceServiceTest.java
+++ b/com.taken_seat.performance-service/src/test/java/com/taken_seat/performance_service/performance/application/service/PerformanceServiceTest.java
@@ -1,6 +1,8 @@
 package com.taken_seat.performance_service.performance.application.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -8,14 +10,69 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.taken_seat.performance_service.performance.application.dto.request.CreatePerformanceScheduleDto;
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.request.CreateSeatPriceDto;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
+import com.taken_seat.performance_service.performance.infrastructure.repository.PerformanceJpaRepository;
 import com.taken_seat.performance_service.performancehall.domain.model.SeatType;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
 class PerformanceServiceTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PerformanceJpaRepository performanceJpaRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+	@Autowired
+	private PerformanceService performanceService;
+
+	public static CreateRequestDto createValidRequestDto() {
+		return CreateRequestDto.builder()
+			.title("뮤지컬 레미제라블")
+			.description("프랑스 혁명을 배경으로 한 감동적인 뮤지컬")
+			.startAt(LocalDateTime.of(2025, 6, 1, 19, 0))
+			.endAt(LocalDateTime.of(2025, 6, 30, 21, 0))
+			.posterUrl("https://image.example.com/posters/les-miserables.jpg")
+			.ageLimit("15")
+			.maxTicketCount(4)
+			.discountInfo("조기 예매 시 10% 할인")
+			.schedules(List.of(
+				CreatePerformanceScheduleDto.builder()
+					.performanceHallId(UUID.fromString("11111111-2222-3333-4444-555555555555"))
+					.startAt(LocalDateTime.of(2025, 6, 10, 19, 0))
+					.endAt(LocalDateTime.of(2025, 6, 10, 21, 0))
+					.saleStartAt(LocalDateTime.of(2025, 5, 1, 10, 0))
+					.saleEndAt(LocalDateTime.of(2025, 6, 9, 23, 59, 59))
+					.seatPrices(List.of(
+						CreateSeatPriceDto.builder()
+							.seatType(SeatType.VIP)
+							.price(150000)
+							.build(),
+						CreateSeatPriceDto.builder()
+							.seatType(SeatType.R)
+							.price(120000)
+							.build()
+					))
+					.build()
+			))
+			.build();
+	}
 
 	/**
 	 * 메서드 호출 시 스케줄과 좌석 가격이 정상적으로 생성이 되는지 단위 테스트 진행
@@ -59,5 +116,48 @@ class PerformanceServiceTest {
 		assertThat(performance.getSchedules().get(0).getSeatPrices()).hasSize(2);
 		assertThat(performance.getSchedules().get(0).getSeatPrices().get(0).getSeatType()).isEqualTo(SeatType.VIP);
 		assertThat(performance.getSchedules().get(0).getSeatPrices().get(1).getPrice()).isEqualTo(120000);
+	}
+
+	/**
+	 * 공연 삭제 성공 시
+	 */
+	@Test
+	@DisplayName("공연 삭제 성공 시 deletedAt, deletedBy가 정상적으로 반영되어야 한다")
+	void deletePerformance_shouldSoftDelete() throws Exception {
+		// given
+		CreateRequestDto requestDto = createValidRequestDto();
+		Performance performance = Performance.create(requestDto);
+		performanceJpaRepository.save(performance);
+		em.flush();
+		em.clear();
+
+		UUID userId = UUID.randomUUID();
+
+		// when
+		mockMvc.perform(delete("/api/v1/performances/" + performance.getId())
+				.param("deletedBy", userId.toString()))
+			.andExpect(status().isNoContent());
+
+		// then
+		Performance deletedPerformance = em.find(Performance.class, performance.getId());
+
+		assertThat(deletedPerformance.getDeletedAt()).isNotNull();
+		assertThat(deletedPerformance.getDeletedBy()).isEqualTo(userId);
+	}
+
+	/**
+	 * 공연 실패 케이스 삭제하려는 ID가 없는 경우
+	 */
+	@Test
+	@DisplayName("삭제 ID가 null이면 예외가 발생한다")
+	void deletePerformance_shouldFail_whenIdIsNull() {
+
+		// given
+		UUID deletedBy = UUID.randomUUID();
+
+		// when & then
+		assertThatThrownBy(() -> performanceService.delete(null, deletedBy))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("삭제할 수 없는 아이디입니다");
 	}
 }


### PR DESCRIPTION
## 개요
softDelete 적용한 공연 삭제 API 구현

## 작업 내용
### 변경 사항

1. **공연 삭제 기능 구현 (Soft Delete 방식)**
   - `Performance.softDelete(UUID deletedBy)` 정적 메서드 구현
   - 삭제 시 `deletedAt`을 현재 시간으로 설정하고, `deletedBy`에 사용자 UUID 저장
   - 실제 삭제 대신 삭제 표시만 하고 조회 대상에서 제외

2. **공연 삭제 API (DELETE /api/v1/performances/{id})**
   - `PerformanceController`에 공연 삭제 API 추가
   - 인증 시스템 미적용 상태로, 현재는 `deletedBy`를 쿼리 파라미터로 전달
   - 추후 `@AuthenticationPrincipal`을 활용한 사용자 인증 방식으로 전환 예정

3. **Repository 구성 및 수정**
   - `PerformanceRepositoryImpl`에서 `findByIdAndDeletedAtIsNull(UUID id)`로 삭제 여부 확인 후 soft delete 처리
   - `PerformanceRepository`에 `deleteById(UUID id, UUID deletedBy)` 정의
   - `PerformanceJpaRepository`에 `findByIdAndDeletedAtIsNull` 메서드 정의

4. **테스트 코드 작성**
   - `deletePerformance_shouldSoftDelete()` 통합 테스트: 삭제 성공 시 `deletedAt`, `deletedBy` 필드 확인
   - `deletePerformance_shouldFail_whenIdIsNull()` 테스트: 공연 ID가 null이면 예외 발생하는지 확인
   - Postman에서도 쿼리 파라미터로 UUID 넘겨서 204 No Content 정상 확인
![image](https://github.com/user-attachments/assets/3d010f76-0918-40e7-b21f-17179e5da501)



### 변경 이유

### 추가 설명
- 현재는 DB에 저장된 실제 사용자 UUID 없이 테스트용 `UUID.randomUUID()` 사용 중
- 추후 보안 기능 적용 시 실제 로그인 사용자 정보 기반으로 수정 예정
- `BaseEntity`는 아직 미적용 상태이며 추후 공통 추상 클래스로 통합 예정

## 리뷰 요구사항

#### 연관된 이슈
closed #34 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
