### PR TITLE
#30 <Performance> 공연 상세 조회 API 구현

### DIFF
--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/mapper/ResponseMapper.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/mapper/ResponseMapper.java
@@ -2,9 +2,9 @@ package com.taken_seat.performance_service.performance.application.dto.mapper;
 
 import java.util.stream.Collectors;
 
-import com.taken_seat.performance_service.performance.application.dto.response.CreatePerformanceScheduleResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
-import com.taken_seat.performance_service.performance.application.dto.response.CreateSeatPriceResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.PerformanceScheduleResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.SeatPriceResponseDto;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 import com.taken_seat.performance_service.performance.domain.model.PerformanceSchedule;
 import com.taken_seat.performance_service.performance.domain.model.PerformanceSeatPrice;
@@ -31,8 +31,8 @@ public class ResponseMapper {
 			.build();
 	}
 
-	private static CreatePerformanceScheduleResponseDto toScheduleDto(PerformanceSchedule schedule) {
-		return CreatePerformanceScheduleResponseDto.builder()
+	private static PerformanceScheduleResponseDto toScheduleDto(PerformanceSchedule schedule) {
+		return PerformanceScheduleResponseDto.builder()
 			.performanceScheduleId(schedule.getId())
 			.performanceHallId(schedule.getPerformanceHallId())
 			.startAt(schedule.getStartAt())
@@ -48,8 +48,8 @@ public class ResponseMapper {
 			.build();
 	}
 
-	private static CreateSeatPriceResponseDto toSeatPriceDto(PerformanceSeatPrice seatPrice) {
-		return CreateSeatPriceResponseDto.builder()
+	private static SeatPriceResponseDto toSeatPriceDto(PerformanceSeatPrice seatPrice) {
+		return SeatPriceResponseDto.builder()
 			.PerformanceSeatPriceId(seatPrice.getId())
 			.seatType(seatPrice.getSeatType())
 			.price(seatPrice.getPrice())

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/mapper/ResponseMapper.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/mapper/ResponseMapper.java
@@ -3,6 +3,7 @@ package com.taken_seat.performance_service.performance.application.dto.mapper;
 import java.util.stream.Collectors;
 
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.DetailResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.PerformanceScheduleResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.SeatPriceResponseDto;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
@@ -50,9 +51,29 @@ public class ResponseMapper {
 
 	private static SeatPriceResponseDto toSeatPriceDto(PerformanceSeatPrice seatPrice) {
 		return SeatPriceResponseDto.builder()
-			.PerformanceSeatPriceId(seatPrice.getId())
+			.performanceSeatPriceId(seatPrice.getId())
 			.seatType(seatPrice.getSeatType())
 			.price(seatPrice.getPrice())
+			.build();
+	}
+
+	public static DetailResponseDto detailToDto(Performance performance) {
+		return DetailResponseDto.builder()
+			.performanceId(performance.getId())
+			.title(performance.getTitle())
+			.description(performance.getDescription())
+			.startAt(performance.getStartAt())
+			.endAt(performance.getEndAt())
+			.status(performance.getStatus())
+			.posterUrl(performance.getPosterUrl())
+			.ageLimit(performance.getAgeLimit())
+			.maxTicketCount(performance.getMaxTicketCount())
+			.discountInfo(performance.getDiscountInfo())
+			.schedules(
+				performance.getSchedules().stream()
+					.map(ResponseMapper::toScheduleDto)
+					.collect(Collectors.toList())
+			)
 			.build();
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/CreateResponseDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/CreateResponseDto.java
@@ -27,5 +27,5 @@ public class CreateResponseDto {
 	private String ageLimit;
 	private Integer maxTicketCount;
 	private String discountInfo;
-	private List<CreatePerformanceScheduleResponseDto> schedules;
+	private List<PerformanceScheduleResponseDto> schedules;
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/DetailResponseDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/DetailResponseDto.java
@@ -1,0 +1,31 @@
+package com.taken_seat.performance_service.performance.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.taken_seat.performance_service.performance.domain.model.PerformanceStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DetailResponseDto {
+
+	private UUID performanceId;
+	private String title;
+	private String description;
+	private LocalDateTime startAt;
+	private LocalDateTime endAt;
+	private PerformanceStatus status;
+	private String posterUrl;
+	private String ageLimit;
+	private Integer maxTicketCount;
+	private String discountInfo;
+	private List<PerformanceScheduleResponseDto> schedules;
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/PerformanceScheduleResponseDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/PerformanceScheduleResponseDto.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 @Builder
 @AllArgsConstructor
 @RequiredArgsConstructor
-public class CreatePerformanceScheduleResponseDto {
+public class PerformanceScheduleResponseDto {
 
 	private UUID performanceScheduleId;
 	private UUID performanceHallId;
@@ -24,6 +24,6 @@ public class CreatePerformanceScheduleResponseDto {
 	private LocalDateTime saleStartAt;
 	private LocalDateTime saleEndAt;
 	private PerformanceScheduleStatus status;
-	private List<CreateSeatPriceResponseDto> seatPrices;
+	private List<SeatPriceResponseDto> seatPrices;
 }
 

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/SeatPriceResponseDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/SeatPriceResponseDto.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 @Builder
 @AllArgsConstructor
 @RequiredArgsConstructor
-public class CreateSeatPriceResponseDto {
+public class SeatPriceResponseDto {
 
 	private UUID PerformanceSeatPriceId;
 	private SeatType seatType;

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/SeatPriceResponseDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/SeatPriceResponseDto.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SeatPriceResponseDto {
 
-	private UUID PerformanceSeatPriceId;
+	private UUID performanceSeatPriceId;
 	private SeatType seatType;
 	private Integer price;
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.DetailResponseDto;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 import com.taken_seat.performance_service.performance.domain.repository.PerformanceRepository;
 
@@ -30,6 +31,16 @@ public class PerformanceService {
 		Performance saved = performanceRepository.save(performance);
 
 		return createToDto(saved);
+
+	}
+
+	@Transactional(readOnly = true)
+	public DetailResponseDto getDetail(UUID id) {
+
+		Performance performance = performanceRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("공연 정보를 찾을 수 없습니다"));
+
+		return detailToDto(performance);
 
 	}
 

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
@@ -2,7 +2,10 @@ package com.taken_seat.performance_service.performance.application.service;
 
 import static com.taken_seat.performance_service.performance.application.dto.mapper.ResponseMapper.*;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
@@ -18,7 +21,8 @@ import lombok.extern.slf4j.Slf4j;
 public class PerformanceService {
 
 	private final PerformanceRepository performanceRepository;
-
+	
+	@Transactional
 	public CreateResponseDto create(CreateRequestDto request) {
 
 		Performance performance = Performance.create(request);
@@ -27,5 +31,15 @@ public class PerformanceService {
 
 		return createToDto(saved);
 
+	}
+
+	@Transactional
+	public void delete(UUID id, UUID deletedBy) {
+
+		if (id == null) {
+			throw new IllegalArgumentException("삭제할 수 없는 아이디입니다");
+		}
+
+		performanceRepository.deleteById(id, deletedBy);
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
@@ -60,6 +60,12 @@ public class Performance {
 
 	private String discountInfo;
 
+	@Column(name = "deleted_by")
+	private UUID deletedBy;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
 	@OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Builder.Default
 	private List<PerformanceSchedule> schedules = new ArrayList<>();
@@ -109,5 +115,11 @@ public class Performance {
 
 		performance.getSchedules().addAll(schedules);
 		return performance;
+	}
+
+	public void softDelete(UUID userId) {
+
+		this.deletedBy = userId;
+		this.deletedAt = LocalDateTime.now();
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/repository/PerformanceRepository.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/repository/PerformanceRepository.java
@@ -1,5 +1,6 @@
 package com.taken_seat.performance_service.performance.domain.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import com.taken_seat.performance_service.performance.domain.model.Performance;
@@ -7,6 +8,8 @@ import com.taken_seat.performance_service.performance.domain.model.Performance;
 public interface PerformanceRepository {
 
 	Performance save(Performance performance);
+
+	Optional<Performance> findById(UUID id);
 
 	void deleteById(UUID id, UUID deletedBy);
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/repository/PerformanceRepository.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/repository/PerformanceRepository.java
@@ -1,8 +1,12 @@
 package com.taken_seat.performance_service.performance.domain.repository;
 
+import java.util.UUID;
+
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 
 public interface PerformanceRepository {
 
 	Performance save(Performance performance);
+
+	void deleteById(UUID id, UUID deletedBy);
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceJpaRepository.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceJpaRepository.java
@@ -1,5 +1,6 @@
 package com.taken_seat.performance_service.performance.infrastructure.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,5 @@ import com.taken_seat.performance_service.performance.domain.model.Performance;
 
 public interface PerformanceJpaRepository extends JpaRepository<Performance, UUID> {
 
+	Optional<Performance> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceRepositoryImpl.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.taken_seat.performance_service.performance.infrastructure.repository;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Repository;
 
 import com.taken_seat.performance_service.performance.domain.model.Performance;
@@ -16,5 +18,14 @@ public class PerformanceRepositoryImpl implements PerformanceRepository {
 	@Override
 	public Performance save(Performance performance) {
 		return performanceJpaRepository.save(performance);
+	}
+
+	@Override
+	public void deleteById(UUID id, UUID deletedBy) {
+
+		Performance performance = performanceJpaRepository.findByIdAndDeletedAtIsNull(id)
+			.orElseThrow(() -> new IllegalArgumentException("이미 삭제된 아이디입니다"));
+
+		performance.softDelete(deletedBy);
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceRepositoryImpl.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.taken_seat.performance_service.performance.infrastructure.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
@@ -18,6 +19,11 @@ public class PerformanceRepositoryImpl implements PerformanceRepository {
 	@Override
 	public Performance save(Performance performance) {
 		return performanceJpaRepository.save(performance);
+	}
+
+	@Override
+	public Optional<Performance> findById(UUID id) {
+		return performanceJpaRepository.findByIdAndDeletedAtIsNull(id);
 	}
 
 	@Override

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.DetailResponseDto;
 import com.taken_seat.performance_service.performance.application.service.PerformanceService;
 
 import jakarta.validation.Valid;
@@ -40,6 +42,19 @@ public class PerformanceController {
 	}
 
 	/**
+	 * 공연 상세 조회 API
+	 * 권한: ALL
+	 */
+	@GetMapping("/{id}")
+	public ResponseEntity<DetailResponseDto> getDetail(@PathVariable("id") UUID id) {
+
+		DetailResponseDto response = performanceService.getDetail(id);
+		return ResponseEntity.status(HttpStatus.OK).body(response);
+	}
+
+	/**
+	 * 공연 삭제 API
+	 * 권한: ADMIN, MANAGER, PRODUCER
 	 * Security 완성 후
 	 * @RequestParam UUID deletedBy -> @AuthenticationPrincipal CustomUserDetails principal 로 수정 예정
 	 */

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
@@ -1,10 +1,15 @@
 package com.taken_seat.performance_service.performance.presentation.controller;
 
+import java.util.UUID;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
@@ -32,5 +37,17 @@ public class PerformanceController {
 		CreateResponseDto response = performanceService.create(request);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 
+	}
+
+	/**
+	 * Security 완성 후
+	 * @RequestParam UUID deletedBy -> @AuthenticationPrincipal CustomUserDetails principal 로 수정 예정
+	 */
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Void> delete(@PathVariable("id") UUID id, @RequestParam UUID deletedBy) {
+
+		performanceService.delete(id, deletedBy);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/model/PerformanceHall.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/model/PerformanceHall.java
@@ -42,5 +42,6 @@ public class PerformanceHall {
 	private String description;
 
 	@OneToMany(mappedBy = "performanceHall", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
 	private List<Seat> seats = new ArrayList<>();
 }

--- a/com.taken_seat.performance-service/src/test/java/com/taken_seat/performance_service/performance/application/service/PerformanceServiceTest.java
+++ b/com.taken_seat.performance-service/src/test/java/com/taken_seat/performance_service/performance/application/service/PerformanceServiceTest.java
@@ -1,6 +1,8 @@
 package com.taken_seat.performance_service.performance.application.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -8,14 +10,69 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.taken_seat.performance_service.performance.application.dto.request.CreatePerformanceScheduleDto;
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.request.CreateSeatPriceDto;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
+import com.taken_seat.performance_service.performance.infrastructure.repository.PerformanceJpaRepository;
 import com.taken_seat.performance_service.performancehall.domain.model.SeatType;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
 class PerformanceServiceTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PerformanceJpaRepository performanceJpaRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+	@Autowired
+	private PerformanceService performanceService;
+
+	public static CreateRequestDto createValidRequestDto() {
+		return CreateRequestDto.builder()
+			.title("뮤지컬 레미제라블")
+			.description("프랑스 혁명을 배경으로 한 감동적인 뮤지컬")
+			.startAt(LocalDateTime.of(2025, 6, 1, 19, 0))
+			.endAt(LocalDateTime.of(2025, 6, 30, 21, 0))
+			.posterUrl("https://image.example.com/posters/les-miserables.jpg")
+			.ageLimit("15")
+			.maxTicketCount(4)
+			.discountInfo("조기 예매 시 10% 할인")
+			.schedules(List.of(
+				CreatePerformanceScheduleDto.builder()
+					.performanceHallId(UUID.fromString("11111111-2222-3333-4444-555555555555"))
+					.startAt(LocalDateTime.of(2025, 6, 10, 19, 0))
+					.endAt(LocalDateTime.of(2025, 6, 10, 21, 0))
+					.saleStartAt(LocalDateTime.of(2025, 5, 1, 10, 0))
+					.saleEndAt(LocalDateTime.of(2025, 6, 9, 23, 59, 59))
+					.seatPrices(List.of(
+						CreateSeatPriceDto.builder()
+							.seatType(SeatType.VIP)
+							.price(150000)
+							.build(),
+						CreateSeatPriceDto.builder()
+							.seatType(SeatType.R)
+							.price(120000)
+							.build()
+					))
+					.build()
+			))
+			.build();
+	}
 
 	/**
 	 * 메서드 호출 시 스케줄과 좌석 가격이 정상적으로 생성이 되는지 단위 테스트 진행
@@ -59,5 +116,48 @@ class PerformanceServiceTest {
 		assertThat(performance.getSchedules().get(0).getSeatPrices()).hasSize(2);
 		assertThat(performance.getSchedules().get(0).getSeatPrices().get(0).getSeatType()).isEqualTo(SeatType.VIP);
 		assertThat(performance.getSchedules().get(0).getSeatPrices().get(1).getPrice()).isEqualTo(120000);
+	}
+
+	/**
+	 * 공연 삭제 성공 시
+	 */
+	@Test
+	@DisplayName("공연 삭제 성공 시 deletedAt, deletedBy가 정상적으로 반영되어야 한다")
+	void deletePerformance_shouldSoftDelete() throws Exception {
+		// given
+		CreateRequestDto requestDto = createValidRequestDto();
+		Performance performance = Performance.create(requestDto);
+		performanceJpaRepository.save(performance);
+		em.flush();
+		em.clear();
+
+		UUID userId = UUID.randomUUID();
+
+		// when
+		mockMvc.perform(delete("/api/v1/performances/" + performance.getId())
+				.param("deletedBy", userId.toString()))
+			.andExpect(status().isNoContent());
+
+		// then
+		Performance deletedPerformance = em.find(Performance.class, performance.getId());
+
+		assertThat(deletedPerformance.getDeletedAt()).isNotNull();
+		assertThat(deletedPerformance.getDeletedBy()).isEqualTo(userId);
+	}
+
+	/**
+	 * 공연 실패 케이스 삭제하려는 ID가 없는 경우
+	 */
+	@Test
+	@DisplayName("삭제 ID가 null이면 예외가 발생한다")
+	void deletePerformance_shouldFail_whenIdIsNull() {
+
+		// given
+		UUID deletedBy = UUID.randomUUID();
+
+		// when & then
+		assertThatThrownBy(() -> performanceService.delete(null, deletedBy))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("삭제할 수 없는 아이디입니다");
 	}
 }

--- a/com.taken_seat.performance-service/src/test/java/com/taken_seat/performance_service/performance/application/service/PerformanceServiceTest.java
+++ b/com.taken_seat.performance-service/src/test/java/com/taken_seat/performance_service/performance/application/service/PerformanceServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -14,11 +15,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.taken_seat.performance_service.performance.application.dto.request.CreatePerformanceScheduleDto;
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.request.CreateSeatPriceDto;
+import com.taken_seat.performance_service.performance.application.dto.response.DetailResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.PerformanceScheduleResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.SeatPriceResponseDto;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 import com.taken_seat.performance_service.performance.infrastructure.repository.PerformanceJpaRepository;
 import com.taken_seat.performance_service.performancehall.domain.model.SeatType;
@@ -74,9 +81,6 @@ class PerformanceServiceTest {
 			.build();
 	}
 
-	/**
-	 * 메서드 호출 시 스케줄과 좌석 가격이 정상적으로 생성이 되는지 단위 테스트 진행
-	 */
 	@DisplayName("Performance.create()는 요청을 받아 schedules와 seatPrices를 생성한다")
 	@Test
 	void create() {
@@ -118,9 +122,81 @@ class PerformanceServiceTest {
 		assertThat(performance.getSchedules().get(0).getSeatPrices().get(1).getPrice()).isEqualTo(120000);
 	}
 
-	/**
-	 * 공연 삭제 성공 시
-	 */
+	@Test
+	@DisplayName("공연 상세 조회 성공 시 응답 dto가 반환되는지 테스트")
+	void getDetail() throws Exception {
+		// given
+		CreateRequestDto requestDto = createValidRequestDto();
+		Performance performance = Performance.create(requestDto);
+		performanceJpaRepository.save(performance);
+
+		// when
+		MvcResult result = mockMvc.perform(get("/api/v1/performances/" + performance.getId()))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		String responseBody = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+		// then: 응답을 DetailResponseDto로 변환하여 값 비교
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+		DetailResponseDto detail = mapper.readValue(responseBody, DetailResponseDto.class);
+
+		// 공연 정보 검증
+		assertThat(detail.getPerformanceId()).isEqualTo(performance.getId());
+		assertThat(detail.getTitle()).isEqualTo(performance.getTitle());
+		assertThat(detail.getDescription()).isEqualTo(performance.getDescription());
+		assertThat(detail.getStartAt()).isEqualTo(performance.getStartAt());
+		assertThat(detail.getEndAt()).isEqualTo(performance.getEndAt());
+		assertThat(detail.getStatus()).isEqualTo(performance.getStatus());
+		assertThat(detail.getPosterUrl()).isEqualTo(performance.getPosterUrl());
+		assertThat(detail.getAgeLimit()).isEqualTo(performance.getAgeLimit());
+		assertThat(detail.getMaxTicketCount()).isEqualTo(performance.getMaxTicketCount());
+		assertThat(detail.getDiscountInfo()).isEqualTo(performance.getDiscountInfo());
+
+		// 회차 정보 검증
+		assertThat(detail.getSchedules()).hasSize(1);
+		PerformanceScheduleResponseDto schedule = detail.getSchedules().get(0);
+
+		// 여기서 기본적으로 저장된 스케줄 값이 일치하는지 확인
+		assertThat(schedule.getStartAt().toString()).isEqualTo(
+			performance.getSchedules().get(0).getStartAt().toString());
+		assertThat(schedule.getEndAt().toString()).isEqualTo(performance.getSchedules().get(0).getEndAt().toString());
+		assertThat(schedule.getSaleStartAt().toString()).isEqualTo(
+			performance.getSchedules().get(0).getSaleStartAt().toString());
+		assertThat(schedule.getSaleEndAt().toString()).isEqualTo(
+			performance.getSchedules().get(0).getSaleEndAt().toString());
+		assertThat(schedule.getPerformanceScheduleId()).isNotNull();
+		assertThat(schedule.getPerformanceHallId().toString()).isEqualTo("11111111-2222-3333-4444-555555555555");
+
+		// 좌석 가격 정보 검증
+		List<SeatPriceResponseDto> seatPrices = schedule.getSeatPrices();
+		assertThat(seatPrices).hasSize(2);
+
+		// 첫 번째 좌석의 값 비교
+		SeatPriceResponseDto vipSeat = seatPrices.get(0);
+		assertThat(vipSeat.getPerformanceSeatPriceId()).isNotNull();
+		assertThat(vipSeat.getSeatType().name()).isEqualTo(SeatType.VIP.name());
+		assertThat(vipSeat.getPrice()).isEqualTo(150000);
+
+		// 두 번째 좌석의 값 비교
+		SeatPriceResponseDto rSeat = seatPrices.get(1);
+		assertThat(rSeat.getPerformanceSeatPriceId()).isNotNull();
+		assertThat(rSeat.getSeatType().name()).isEqualTo(SeatType.R.name());
+		assertThat(rSeat.getPrice()).isEqualTo(120000);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 ID로 공연 상세 조회 시 예외가 발생해야 한다 (Service 테스트)")
+	void getDetail_shouldFail_whenPerformanceIdNotExist() {
+		// given
+		UUID fakeId = UUID.randomUUID();
+
+		// when & then
+		assertThatThrownBy(() -> performanceService.getDetail(fakeId))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
 	@Test
 	@DisplayName("공연 삭제 성공 시 deletedAt, deletedBy가 정상적으로 반영되어야 한다")
 	void deletePerformance_shouldSoftDelete() throws Exception {
@@ -128,8 +204,6 @@ class PerformanceServiceTest {
 		CreateRequestDto requestDto = createValidRequestDto();
 		Performance performance = Performance.create(requestDto);
 		performanceJpaRepository.save(performance);
-		em.flush();
-		em.clear();
 
 		UUID userId = UUID.randomUUID();
 
@@ -145,11 +219,8 @@ class PerformanceServiceTest {
 		assertThat(deletedPerformance.getDeletedBy()).isEqualTo(userId);
 	}
 
-	/**
-	 * 공연 실패 케이스 삭제하려는 ID가 없는 경우
-	 */
 	@Test
-	@DisplayName("삭제 ID가 null이면 예외가 발생한다")
+	@DisplayName("공연 실패 케이스 삭제하려는 ID가 없는 경우")
 	void deletePerformance_shouldFail_whenIdIsNull() {
 
 		// given


### PR DESCRIPTION
## 개요
공연 상세 조회 기능을 구현

## 작업 내용
### 변경 사항

- `GET /api/v1/performances/{performanceId}` API 구현
- `PerformanceService.getDetail(UUID performanceId)` 로직 구현
- `PerformanceRepository` 및 `PerformanceRepositoryImpl` 상세 조회 메서드 추가
- `DetailResponseDto`, `PerformanceScheduleResponseDto`, `SeatPriceResponseDto` 작성
- `ResponseMapper`를 통한 도메인 → 응답 DTO 변환 로직 추가
- 테스트 진행
   - 상세 조회 성공 케이스 테스트 코드 작성
   - 존재하지 않는 공연 ID 조회 시 예외 테스트 코드 작성
   - 포스트맨 테스트 진행
![image](https://github.com/user-attachments/assets/b33f42fa-18ef-49e6-ba5b-8ec351f30360)

### 변경 이유

### 추가 설명
- 현재는 존재하지 않는 공연 ID로 요청 시 500 에러가 반환되도록 설정되어 있으며, 추후 GlobalExceptionHandler를 도입하여 404로 응답하도록 개선 예정입니다.

## 리뷰 요구사항

#### 연관된 이슈
closed #30 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [X] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
