### PR TITLE
#24 <Booking> 예매 조회 API 구현

### DIFF
--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/application/BookingService.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/application/BookingService.java
@@ -1,8 +1,19 @@
 package com.taken_seat.booking_service.application;
 
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
+
 import com.taken_seat.booking_service.application.dto.request.BookingCreateRequest;
 import com.taken_seat.booking_service.application.dto.response.BookingCreateResponse;
+import com.taken_seat.booking_service.application.dto.response.BookingPageResponse;
+import com.taken_seat.booking_service.application.dto.response.BookingReadResponse;
 
 public interface BookingService {
 	BookingCreateResponse createBooking(BookingCreateRequest request);
+
+	BookingReadResponse readBooking(UUID id);
+
+	BookingPageResponse readBookings(Pageable pageable, UUID userId);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/application/dto/response/BookingPageResponse.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/application/dto/response/BookingPageResponse.java
@@ -1,0 +1,39 @@
+package com.taken_seat.booking_service.application.dto.response;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+
+import com.taken_seat.booking_service.domain.Booking;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@NoArgsConstructor
+public class BookingPageResponse {
+	private List<BookingReadResponse> content;
+	private int pageNumber;
+	private int pageSize;
+	private int totalPages;
+	private long totalElements;
+	private boolean isLast;
+
+	public static BookingPageResponse toDto(Page<Booking> page) {
+		return BookingPageResponse.builder()
+			.content(page.getContent().stream()
+				.map(BookingReadResponse::toDto)
+				.collect(Collectors.toList()))
+			.pageNumber(page.getNumber())
+			.pageSize(page.getSize())
+			.totalPages(page.getTotalPages())
+			.totalElements(page.getTotalElements())
+			.isLast(page.isLast())
+			.build();
+	}
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/application/dto/response/BookingReadResponse.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/application/dto/response/BookingReadResponse.java
@@ -1,0 +1,38 @@
+package com.taken_seat.booking_service.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.taken_seat.booking_service.domain.Booking;
+import com.taken_seat.booking_service.domain.BookingStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@NoArgsConstructor
+public class BookingReadResponse {
+	private UUID id;
+	private UUID performanceScheduleId;
+	private UUID seatId;
+	private UUID paymentId;
+	private BookingStatus bookingStatus;
+	private LocalDateTime bookedAt;
+	private LocalDateTime canceledAt;
+
+	public static BookingReadResponse toDto(Booking booking) {
+		return BookingReadResponse.builder()
+			.id(booking.getId())
+			.performanceScheduleId(booking.getPerformanceScheduleId())
+			.seatId(booking.getSeatId())
+			.paymentId(booking.getPaymentId())
+			.bookingStatus(booking.getBookingStatus())
+			.bookedAt(booking.getBookedAt())
+			.canceledAt(booking.getCanceledAt())
+			.build();
+	}
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/domain/repository/BookingRepository.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/domain/repository/BookingRepository.java
@@ -2,6 +2,8 @@ package com.taken_seat.booking_service.domain.repository;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,5 @@ import com.taken_seat.booking_service.domain.Booking;
 
 @Repository
 public interface BookingRepository extends JpaRepository<Booking, UUID> {
+	Page<Booking> findAllByUserId(Pageable pageable, UUID userId);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/infrastructure/service/BookingServiceImpl.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/infrastructure/service/BookingServiceImpl.java
@@ -1,13 +1,20 @@
 package com.taken_seat.booking_service.infrastructure.service;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.taken_seat.booking_service.application.BookingService;
 import com.taken_seat.booking_service.application.RedissonService;
 import com.taken_seat.booking_service.application.dto.request.BookingCreateRequest;
 import com.taken_seat.booking_service.application.dto.response.BookingCreateResponse;
+import com.taken_seat.booking_service.application.dto.response.BookingPageResponse;
+import com.taken_seat.booking_service.application.dto.response.BookingReadResponse;
 import com.taken_seat.booking_service.domain.Booking;
 import com.taken_seat.booking_service.domain.repository.BookingRepository;
 
@@ -21,6 +28,7 @@ public class BookingServiceImpl implements BookingService {
 	private final BookingRepository bookingRepository;
 
 	@Override
+	@Transactional
 	public BookingCreateResponse createBooking(BookingCreateRequest request) {
 
 		UUID userId = UUID.randomUUID();
@@ -35,5 +43,25 @@ public class BookingServiceImpl implements BookingService {
 		Booking saved = bookingRepository.save(booking);
 
 		return BookingCreateResponse.toDto(saved);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public BookingReadResponse readBooking(UUID id) {
+
+		// TODO: 사용자의 예매만 조회할 것
+		Booking booking = bookingRepository.findById(id).orElseThrow(() -> new RuntimeException("존재하지 않는 예약입니다."));
+
+		return BookingReadResponse.toDto(booking);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public BookingPageResponse readBookings(Pageable pageable, UUID userId) {
+
+		// TODO: 사용자의 예매만 조회할 것
+		Page<Booking> page = bookingRepository.findAllByUserId(pageable, userId);
+
+		return BookingPageResponse.toDto(page);
 	}
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/presentation/BookingController.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/presentation/BookingController.java
@@ -1,14 +1,23 @@
 package com.taken_seat.booking_service.presentation;
 
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.taken_seat.booking_service.application.BookingService;
 import com.taken_seat.booking_service.application.dto.request.BookingCreateRequest;
 import com.taken_seat.booking_service.application.dto.response.BookingCreateResponse;
+import com.taken_seat.booking_service.application.dto.response.BookingPageResponse;
+import com.taken_seat.booking_service.application.dto.response.BookingReadResponse;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +32,20 @@ public class BookingController {
 	@PostMapping
 	public ResponseEntity<BookingCreateResponse> createBooking(@RequestBody @Valid BookingCreateRequest request) {
 		BookingCreateResponse response = bookingService.createBooking(request);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<BookingReadResponse> readBooking(@PathVariable("id") UUID id) {
+		BookingReadResponse response = bookingService.readBooking(id);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping
+	public ResponseEntity<BookingPageResponse> readBookings(Pageable pageable, @RequestParam("userId") UUID userId) {
+		BookingPageResponse response = bookingService.readBookings(pageable, userId);
 
 		return ResponseEntity.ok(response);
 	}

--- a/com.taken_seat.booking-service/src/test/java/com/taken_seat/booking_service/infrastructure/service/BookingServiceTest.java
+++ b/com.taken_seat.booking-service/src/test/java/com/taken_seat/booking_service/infrastructure/service/BookingServiceTest.java
@@ -1,72 +1,90 @@
 package com.taken_seat.booking_service.infrastructure.service;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
 
-import com.taken_seat.booking_service.application.BookingService;
-import com.taken_seat.booking_service.application.dto.request.BookingCreateRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.taken_seat.booking_service.application.dto.response.BookingPageResponse;
+import com.taken_seat.booking_service.application.dto.response.BookingReadResponse;
+import com.taken_seat.booking_service.domain.Booking;
+import com.taken_seat.booking_service.domain.repository.BookingRepository;
 
 @SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
 class BookingServiceTest {
 
 	@Autowired
-	private BookingService bookingService;
+	private MockMvc mockMvc;
 
-	private final UUID seatId = UUID.randomUUID();
+	@Autowired
+	private BookingRepository bookingRepository;
+
+	@Autowired
+	private ObjectMapper objectMapper;
 
 	@Test
-	@DisplayName("동시 요청시 하나만 성공")
-	void test() throws InterruptedException {
-		int threadCount = 10;
-		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-		CountDownLatch latch = new CountDownLatch(threadCount);
+	@DisplayName("단건 조회 테스트")
+	void test1() throws Exception {
+		Booking booking = Booking.builder()
+			.userId(UUID.randomUUID())
+			.performanceScheduleId(UUID.randomUUID())
+			.seatId(UUID.randomUUID())
+			.build();
 
-		List<Future<String>> results = new ArrayList<>();
+		Booking saved = bookingRepository.saveAndFlush(booking);
 
-		for (int i = 0; i < threadCount; i++) {
-			int userIndex = i;
-			results.add(executorService.submit(() -> {
-				try {
-					BookingCreateRequest request = BookingCreateRequest.builder()
-						.seatId(seatId)
-						.build();
+		MvcResult mvcResult = mockMvc.perform(get("/api/v1/bookings/" + saved.getId()))
+			.andExpect(status().isOk())
+			.andReturn();
 
-					bookingService.createBooking(request);
-					return "SUCCESS: 사용자 " + userIndex;
-				} catch (Exception e) {
-					return "FAIL: 사용자 " + userIndex + " -> " + e.getMessage();
-				} finally {
-					latch.countDown();
-				}
-			}));
-		}
+		String contentAsString = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+		BookingReadResponse response = objectMapper.readValue(contentAsString, BookingReadResponse.class);
 
-		latch.await();
+		assertEquals(response.getId(), saved.getId());
+	}
 
-		long successCount = results.stream()
-			.map(f -> {
-				try {
-					return f.get();
-				} catch (Exception e) {
-					return "FAIL";
-				}
-			})
-			.peek(System.out::println)
-			.filter(msg -> msg.startsWith("SUCCESS"))
-			.count();
+	@Test
+	@DisplayName("페이지 조회 테스트")
+	void test2() throws Exception {
+		UUID userId = UUID.randomUUID();
 
-		assertEquals(successCount, 1);
+		Booking booking1 = Booking.builder()
+			.userId(userId)
+			.performanceScheduleId(UUID.randomUUID())
+			.seatId(UUID.randomUUID())
+			.build();
+
+		Booking booking2 = Booking.builder()
+			.userId(userId)
+			.performanceScheduleId(UUID.randomUUID())
+			.seatId(UUID.randomUUID())
+			.build();
+
+		List<Booking> list = List.of(booking1, booking2);
+		bookingRepository.saveAllAndFlush(list);
+
+		MvcResult mvcResult = mockMvc.perform(get("/api/v1/bookings").param("userId", userId.toString()))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		String contentAsString = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+		BookingPageResponse response = objectMapper.readValue(contentAsString, BookingPageResponse.class);
+
+		assertEquals(response.getTotalElements(), list.size());
 	}
 }

--- a/com.taken_seat.booking-service/src/test/java/com/taken_seat/booking_service/infrastructure/service/ConcurrencyTest.java
+++ b/com.taken_seat.booking-service/src/test/java/com/taken_seat/booking_service/infrastructure/service/ConcurrencyTest.java
@@ -1,0 +1,74 @@
+package com.taken_seat.booking_service.infrastructure.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.taken_seat.booking_service.application.BookingService;
+import com.taken_seat.booking_service.application.dto.request.BookingCreateRequest;
+
+@SpringBootTest
+@Transactional
+class ConcurrencyTest {
+
+	@Autowired
+	private BookingService bookingService;
+
+	private final UUID seatId = UUID.randomUUID();
+
+	@Test
+	@DisplayName("동시 요청시 하나만 성공")
+	void test() throws InterruptedException {
+		int threadCount = 20;
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		List<Future<String>> results = new ArrayList<>();
+
+		for (int i = 0; i < threadCount; i++) {
+			int userIndex = i;
+			results.add(executorService.submit(() -> {
+				try {
+					BookingCreateRequest request = BookingCreateRequest.builder()
+						.seatId(seatId)
+						.build();
+
+					bookingService.createBooking(request);
+					return "SUCCESS: 사용자 " + userIndex;
+				} catch (Exception e) {
+					return "FAIL: 사용자 " + userIndex + " -> " + e.getMessage();
+				} finally {
+					latch.countDown();
+				}
+			}));
+		}
+
+		latch.await();
+
+		long successCount = results.stream()
+			.map(f -> {
+				try {
+					return f.get();
+				} catch (Exception e) {
+					return "FAIL";
+				}
+			})
+			.peek(System.out::println)
+			.filter(msg -> msg.startsWith("SUCCESS"))
+			.count();
+
+		assertEquals(successCount, 1);
+	}
+}


### PR DESCRIPTION
## 개요
예매 조회 API 를 간단히 구현했습니다.

## 작업 내용
### 변경 사항
1. `readBooking` 단건 조회
    - 예매 ID로 조회
    ```java
    public class BookingReadResponse {
      private UUID id;
      private UUID performanceScheduleId;
      private UUID seatId;
      private UUID paymentId;
      private BookingStatus bookingStatus;
      private LocalDateTime bookedAt;
      private LocalDateTime canceledAt;
    }
    ```
2. `readBookings` 리스트 조회
    ```java
    public class BookingPageResponse {
      private List<BookingReadResponse> content;
      private int pageNumber;
      private int pageSize;
      private int totalPages;
      private long totalElements;
      private boolean isLast;
    }
    ```
4. 조회 테스트 코드 작성
![image](https://github.com/user-attachments/assets/dc239c3a-346c-4fd5-b707-9640dad561ee)

### 변경 이유

### 추가 설명
추후 Security 를 통해 받아온 UserId 로 해당 UserId 의 예매만 조회할 수 있도록 수정해야함
## 리뷰 요구사항

#### 연관된 이슈
#24

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
