### PR TITLE
#26 <Booking> 예매 삭제 기능

### DIFF
--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/BookingServiceApplication.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/BookingServiceApplication.java
@@ -11,5 +11,4 @@ public class BookingServiceApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(BookingServiceApplication.class, args);
 	}
-
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/application/BookingService.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/application/BookingService.java
@@ -17,4 +17,6 @@ public interface BookingService {
 	BookingPageResponse readBookings(Pageable pageable, UUID userId);
 
 	void updateBooking(UUID id);
+
+	void deleteBooking(UUID id);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/infrastructure/service/BookingServiceImpl.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/infrastructure/service/BookingServiceImpl.java
@@ -80,4 +80,17 @@ public class BookingServiceImpl implements BookingService {
 
 		// TODO: 좌석 선점 해제 요청 보내기
 	}
+
+	@Override
+	@Transactional
+	public void deleteBooking(UUID id) {
+		UUID userId = UUID.randomUUID();
+		Booking booking = bookingRepository.findById(id).orElseThrow(() -> new RuntimeException("존재하지 않는 예약입니다."));
+
+		if (booking.getCanceledAt() == null) {
+			throw new RuntimeException("예약 취소 후 삭제할 수 있습니다.");
+		}
+
+		booking.delete(userId);
+	}
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/presentation/BookingController.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/presentation/BookingController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -54,6 +55,13 @@ public class BookingController {
 	@PatchMapping("/{id}")
 	public ResponseEntity<Void> updateBooking(@PathVariable("id") UUID id) {
 		bookingService.updateBooking(id);
+
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Void> deleteBooking(@PathVariable("id") UUID id) {
+		bookingService.deleteBooking(id);
 
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}

--- a/com.taken_seat.booking-service/src/test/java/com/taken_seat/booking_service/infrastructure/service/BookingServiceTest.java
+++ b/com.taken_seat.booking-service/src/test/java/com/taken_seat/booking_service/infrastructure/service/BookingServiceTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -103,6 +104,22 @@ class BookingServiceTest {
 			.andExpect(status().isNoContent());
 
 		assertNotNull(saved.getCanceledAt());
+	}
+
+	@Test
+	@DisplayName("예매 삭제 테스트")
+	void test4() throws Exception {
+		Booking booking = Booking.builder()
+			.userId(UUID.randomUUID())
+			.performanceScheduleId(UUID.randomUUID())
+			.seatId(UUID.randomUUID())
+			.canceledAt(LocalDateTime.now())
+			.build();
+
+		Booking saved = bookingRepository.saveAndFlush(booking);
+
+		mockMvc.perform(delete("/api/v1/bookings/" + saved.getId()))
+			.andExpect(status().isNoContent());
 	}
 
 }


### PR DESCRIPTION
## 개요
예매 삭제 기능을 추가했습니다.

## 작업 내용
### 변경 사항
1. 예매 삭제 기능 추가
    - 예매 삭제 시 예매가 취소되지 않았다면 예외 발생

### 변경 이유

### 추가 설명
추후에 예매한 공연이 끝났는 지 확인하는 로직이 필요할 듯 합니다.
## 리뷰 요구사항

#### 연관된 이슈
#26

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
