### PR TITLE
#31 <Performance> 공연 전체 조회 API

### DIFF
--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/mapper/ResponseMapper.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/mapper/ResponseMapper.java
@@ -106,7 +106,7 @@ public class ResponseMapper {
 		return PageResponseDto.builder()
 			.content(content)
 			.pageSize(pages.getSize())
-			.pageNumber(pages.getNumber())
+			.pageNumber(pages.getNumber() + 1)
 			.totalPages(pages.getTotalPages())
 			.totalElements(pages.getTotalElements())
 			.isLast(pages.isLast())

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/mapper/ResponseMapper.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/mapper/ResponseMapper.java
@@ -1,15 +1,22 @@
 package com.taken_seat.performance_service.performance.application.dto.mapper;
 
+import java.util.List;
 import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
 
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.DetailResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.PageResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.PerformanceScheduleResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.SearchResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.SeatPriceResponseDto;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 import com.taken_seat.performance_service.performance.domain.model.PerformanceSchedule;
 import com.taken_seat.performance_service.performance.domain.model.PerformanceSeatPrice;
 
+@Component
 public class ResponseMapper {
 
 	public static CreateResponseDto createToDto(Performance performance) {
@@ -74,6 +81,35 @@ public class ResponseMapper {
 					.map(ResponseMapper::toScheduleDto)
 					.collect(Collectors.toList())
 			)
+			.build();
+	}
+
+	public SearchResponseDto toSearch(Performance performance) {
+		return SearchResponseDto.builder()
+			.title(performance.getTitle())
+			.startAt(performance.getStartAt())
+			.endAt(performance.getEndAt())
+			.status(performance.getStatus())
+			.posterUrl(performance.getPosterUrl())
+			.build();
+	}
+
+	public List<SearchResponseDto> toSearchList(List<Performance> performances) {
+		return performances.stream()
+			.map(this::toSearch)
+			.collect(Collectors.toList());
+	}
+
+	public PageResponseDto toPage(Page<Performance> pages) {
+		List<SearchResponseDto> content = toSearchList(pages.getContent());
+
+		return PageResponseDto.builder()
+			.content(content)
+			.pageSize(pages.getSize())
+			.pageNumber(pages.getNumber())
+			.totalPages(pages.getTotalPages())
+			.totalElements(pages.getTotalElements())
+			.isLast(pages.isLast())
 			.build();
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/request/SearchFilterParam.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/request/SearchFilterParam.java
@@ -1,0 +1,22 @@
+package com.taken_seat.performance_service.performance.application.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.taken_seat.performance_service.performance.domain.model.PerformanceStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchFilterParam {
+
+	private String title;
+	private LocalDateTime startAt;
+	private LocalDateTime endAt;
+	private PerformanceStatus status;
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/request/SearchFilterParam.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/request/SearchFilterParam.java
@@ -8,8 +8,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/PageResponseDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/PageResponseDto.java
@@ -1,0 +1,22 @@
+package com.taken_seat.performance_service.performance.application.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PageResponseDto {
+
+	private List<SearchResponseDto> content;
+	private int pageSize;
+	private int pageNumber;
+	private int totalPages;
+	private long totalElements;
+	private boolean isLast;
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/SearchResponseDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/SearchResponseDto.java
@@ -1,0 +1,23 @@
+package com.taken_seat.performance_service.performance.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.taken_seat.performance_service.performance.domain.model.PerformanceStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchResponseDto {
+
+	private String title;
+	private LocalDateTime startAt;
+	private LocalDateTime endAt;
+	private PerformanceStatus status;
+	private String posterUrl;
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
@@ -4,12 +4,17 @@ import static com.taken_seat.performance_service.performance.application.dto.map
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.taken_seat.performance_service.performance.application.dto.mapper.ResponseMapper;
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
+import com.taken_seat.performance_service.performance.application.dto.request.SearchFilterParam;
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.DetailResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.PageResponseDto;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 import com.taken_seat.performance_service.performance.domain.repository.PerformanceRepository;
 
@@ -22,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PerformanceService {
 
 	private final PerformanceRepository performanceRepository;
+	private final ResponseMapper responseMapper;
 
 	@Transactional
 	public CreateResponseDto create(CreateRequestDto request) {
@@ -35,13 +41,20 @@ public class PerformanceService {
 	}
 
 	@Transactional(readOnly = true)
+	public PageResponseDto search(SearchFilterParam filterParam, Pageable pageable) {
+
+		Page<Performance> pages = performanceRepository.findAll(filterParam, pageable);
+
+		return responseMapper.toPage(pages);
+	}
+
+	@Transactional(readOnly = true)
 	public DetailResponseDto getDetail(UUID id) {
 
 		Performance performance = performanceRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("공연 정보를 찾을 수 없습니다"));
 
 		return detailToDto(performance);
-
 	}
 
 	@Transactional

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/repository/PerformanceRepository.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/repository/PerformanceRepository.java
@@ -3,6 +3,10 @@ package com.taken_seat.performance_service.performance.domain.repository;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.taken_seat.performance_service.performance.application.dto.request.SearchFilterParam;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 
 public interface PerformanceRepository {
@@ -10,6 +14,8 @@ public interface PerformanceRepository {
 	Performance save(Performance performance);
 
 	Optional<Performance> findById(UUID id);
+
+	Page<Performance> findAll(SearchFilterParam filterParam, Pageable pageable);
 
 	void deleteById(UUID id, UUID deletedBy);
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/repository/spec/PerformanceSpecification.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/repository/spec/PerformanceSpecification.java
@@ -1,0 +1,73 @@
+package com.taken_seat.performance_service.performance.domain.repository.spec;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import com.taken_seat.performance_service.performance.application.dto.request.SearchFilterParam;
+import com.taken_seat.performance_service.performance.domain.model.Performance;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+
+public class PerformanceSpecification {
+
+	public static Specification<Performance> withFilter(SearchFilterParam filterParam) {
+		return (root, query, criteriaBuilder) -> {
+			List<Predicate> predicates = new ArrayList<>();
+
+			predicates.add(criteriaBuilder.isNull(root.get("deletedAt")));
+
+			addTitleCondition(predicates, root, criteriaBuilder, filterParam);
+			addDateCondition(predicates, root, criteriaBuilder, filterParam);
+			addStatusCondition(predicates, root, criteriaBuilder, filterParam);
+
+			return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+		};
+	}
+
+	/**
+	 * 타이틀 검색 조건
+	 */
+	private static void addTitleCondition(List<Predicate> predicates, Root<Performance> root,
+		CriteriaBuilder cb, SearchFilterParam filterParam) {
+		if (filterParam.getTitle() != null) {
+			predicates.add(cb.like(root.get("title"), "%" + filterParam.getTitle() + "%"));
+		}
+	}
+
+	/**
+	 * 날짜 조건
+	 * 1. 둘 다 입력: 시작일 ~ 종료일
+	 * 2. 시작일만 입력: 시작일 이후 시작되는 공연 조회
+	 * 3. 종료일만 입력: 종료일 이전에 시작되는 공연 조회
+	 */
+	private static void addDateCondition(List<Predicate> predicates, Root<Performance> root,
+		CriteriaBuilder cb, SearchFilterParam filterParam) {
+
+		LocalDateTime start = filterParam.getStartAt();
+		LocalDateTime end = filterParam.getEndAt();
+
+		if (start != null && end != null) {
+			predicates.add(cb.between(root.get("startAt"), start, end));
+		} else if (start != null) {
+			predicates.add(cb.greaterThanOrEqualTo(root.get("startAt"), start));
+		} else if (end != null) {
+			predicates.add(cb.lessThanOrEqualTo(root.get("startAt"), end));
+		}
+	}
+
+	/**
+	 * 상태 조건
+	 */
+	private static void addStatusCondition(List<Predicate> predicates, Root<Performance> root,
+		CriteriaBuilder cb, SearchFilterParam filterParam) {
+		if (filterParam.getStatus() != null) {
+			predicates.add(cb.equal(root.get("status"), filterParam.getStatus()));
+		}
+	}
+}
+

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceJpaRepository.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceJpaRepository.java
@@ -4,10 +4,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 
-public interface PerformanceJpaRepository extends JpaRepository<Performance, UUID> {
+public interface PerformanceJpaRepository
+	extends JpaRepository<Performance, UUID>, JpaSpecificationExecutor<Performance> {
 
 	Optional<Performance> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceRepositoryImpl.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/repository/PerformanceRepositoryImpl.java
@@ -3,10 +3,14 @@ package com.taken_seat.performance_service.performance.infrastructure.repository
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import com.taken_seat.performance_service.performance.application.dto.request.SearchFilterParam;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 import com.taken_seat.performance_service.performance.domain.repository.PerformanceRepository;
+import com.taken_seat.performance_service.performance.domain.repository.spec.PerformanceSpecification;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +28,15 @@ public class PerformanceRepositoryImpl implements PerformanceRepository {
 	@Override
 	public Optional<Performance> findById(UUID id) {
 		return performanceJpaRepository.findByIdAndDeletedAtIsNull(id);
+	}
+
+	@Override
+	public Page<Performance> findAll(SearchFilterParam filterParam, Pageable pageable) {
+
+		return performanceJpaRepository.findAll(
+			PerformanceSpecification.withFilter(filterParam),
+			pageable
+		);
 	}
 
 	@Override

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
@@ -2,10 +2,14 @@ package com.taken_seat.performance_service.performance.presentation.controller;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,8 +18,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
+import com.taken_seat.performance_service.performance.application.dto.request.SearchFilterParam;
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.DetailResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.PageResponseDto;
 import com.taken_seat.performance_service.performance.application.service.PerformanceService;
 
 import jakarta.validation.Valid;
@@ -39,6 +45,19 @@ public class PerformanceController {
 		CreateResponseDto response = performanceService.create(request);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 
+	}
+
+	/**
+	 * 공연 전체 조회 API
+	 * 권한: ALL
+	 */
+	@GetMapping("/search")
+	public ResponseEntity<PageResponseDto> getList(
+		@ModelAttribute SearchFilterParam filterParam,
+		@PageableDefault(page = 0, size = 10, sort = "startAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+		PageResponseDto response = performanceService.search(filterParam, pageable);
+		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 
 	/**


### PR DESCRIPTION
## 개요
공연 전체 조회 기능을 구현했습니다.

## 작업 내용
### 변경 사항

1. **공연 전체 조회 API 구현** (`GET /api/v1/performances/search`)
   - title, startAt, endAt, status 조건 검색
   - Pageable 기반 정렬 및 페이징 처리
   - 기본 정렬: startAt DESC

2. **DTO 구성**
   - `SearchFilterParam`: 검색 필터 요청 DTO
   - `SearchResponseDto`: 단일 공연 리스트 응답 DTO
   - `PageResponseDto`: 페이지 정보 포함 응답 DTO

3. **Specification 적용**
   - `PerformanceSpecification.withFilter()`로 조건 동적 조합
   - 단일 책임 원칙에 따라 title, date, status 조건 메서드 분리

4. **Mapper**
   - `ResponseMapper.toSearch`, `toSearchList`, `toPage` 메서드로 응답 변환 로직 구성
   - pageNumber는 0 → 1 기본 적용

5. **Repository 구조**
   - `PerformanceRepository`: 도메인 중심 Repository 인터페이스
   - `PerformanceRepositoryImpl`: JpaSpecificationExecutor 기반 구현
   - `PerformanceJpaRepository`: JPA + Specification 지원

6. **바인딩 문제 해결**
   - `SearchFilterParam`에 `@Setter` 추가하여 `@ModelAttribute` 정상 바인딩 처리

7. **테스트 진행**
   - 테스트 코드는 이후 진행 예정
   - Postman 테스트 완료
     - 타이틀 검색, 날짜 조건, 상태 조건
![image](https://github.com/user-attachments/assets/50a94939-0092-45c1-9e08-25d0d5af5d61)

### 변경 이유

### 추가 설명
- 검색 조건이 늘어나면서 JPA 메서드 방식으로는 확장에 한계가 있어 Specification 적용했습니다.

## 리뷰 요구사항

#### 연관된 이슈
closed #31

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [X] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
