### PR TITLE
#33 <Performance> 공연 수정 API 구현

### DIFF
--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/mapper/ResponseMapper.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/mapper/ResponseMapper.java
@@ -12,6 +12,7 @@ import com.taken_seat.performance_service.performance.application.dto.response.P
 import com.taken_seat.performance_service.performance.application.dto.response.PerformanceScheduleResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.SearchResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.SeatPriceResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.UpdateResponseDto;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 import com.taken_seat.performance_service.performance.domain.model.PerformanceSchedule;
 import com.taken_seat.performance_service.performance.domain.model.PerformanceSeatPrice;
@@ -85,7 +86,9 @@ public class ResponseMapper {
 	}
 
 	public SearchResponseDto toSearch(Performance performance) {
+
 		return SearchResponseDto.builder()
+			.performanceId(performance.getId())
 			.title(performance.getTitle())
 			.startAt(performance.getStartAt())
 			.endAt(performance.getEndAt())
@@ -101,8 +104,8 @@ public class ResponseMapper {
 	}
 
 	public PageResponseDto toPage(Page<Performance> pages) {
-		List<SearchResponseDto> content = toSearchList(pages.getContent());
 
+		List<SearchResponseDto> content = toSearchList(pages.getContent());
 		return PageResponseDto.builder()
 			.content(content)
 			.pageSize(pages.getSize())
@@ -110,6 +113,39 @@ public class ResponseMapper {
 			.totalPages(pages.getTotalPages())
 			.totalElements(pages.getTotalElements())
 			.isLast(pages.isLast())
+			.build();
+	}
+
+	public static UpdateResponseDto toUpdate(Performance performance) {
+		return UpdateResponseDto.builder()
+			.performanceId(performance.getId())
+			.title(performance.getTitle())
+			.description(performance.getDescription())
+			.startAt(performance.getStartAt())
+			.endAt(performance.getEndAt())
+			.status(performance.getStatus())
+			.posterUrl(performance.getPosterUrl())
+			.ageLimit(performance.getAgeLimit())
+			.maxTicketCount(performance.getMaxTicketCount())
+			.discountInfo(performance.getDiscountInfo())
+			.schedules(performance.getSchedules().stream()
+				.map(schedule -> PerformanceScheduleResponseDto.builder()
+					.performanceScheduleId(schedule.getId())
+					.performanceHallId(schedule.getPerformanceHallId())
+					.startAt(schedule.getStartAt())
+					.endAt(schedule.getEndAt())
+					.saleStartAt(schedule.getSaleStartAt())
+					.saleEndAt(schedule.getSaleEndAt())
+					.status(schedule.getStatus())
+					.seatPrices(schedule.getSeatPrices().stream()
+						.map(seatPrice -> SeatPriceResponseDto.builder()
+							.performanceSeatPriceId(seatPrice.getId())
+							.seatType(seatPrice.getSeatType())
+							.price(seatPrice.getPrice())
+							.build())
+						.toList())
+					.build())
+				.toList())
 			.build();
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/request/UpdatePerformanceScheduleDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/request/UpdatePerformanceScheduleDto.java
@@ -1,0 +1,29 @@
+package com.taken_seat.performance_service.performance.application.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.taken_seat.performance_service.performance.domain.model.PerformanceScheduleStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class UpdatePerformanceScheduleDto {
+
+	private UUID performanceScheduleId;
+	private UUID performanceHallId;
+	private LocalDateTime startAt;
+	private LocalDateTime endAt;
+	private LocalDateTime saleStartAt;
+	private LocalDateTime saleEndAt;
+	private PerformanceScheduleStatus status;
+	private List<UpdateSeatPriceDto> seatPrices;
+}
+

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/request/UpdateRequestDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/request/UpdateRequestDto.java
@@ -1,6 +1,7 @@
-package com.taken_seat.performance_service.performance.application.dto.response;
+package com.taken_seat.performance_service.performance.application.dto.request;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import com.taken_seat.performance_service.performance.domain.model.PerformanceStatus;
@@ -8,18 +9,23 @@ import com.taken_seat.performance_service.performance.domain.model.PerformanceSt
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
-public class SearchResponseDto {
+@RequiredArgsConstructor
+public class UpdateRequestDto {
 
 	private UUID performanceId;
 	private String title;
+	private String description;
 	private LocalDateTime startAt;
 	private LocalDateTime endAt;
 	private PerformanceStatus status;
 	private String posterUrl;
+	private String ageLimit;
+	private Integer maxTicketCount;
+	private String discountInfo;
+	private List<UpdatePerformanceScheduleDto> schedules;
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/request/UpdateSeatPriceDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/request/UpdateSeatPriceDto.java
@@ -1,0 +1,21 @@
+package com.taken_seat.performance_service.performance.application.dto.request;
+
+import java.util.UUID;
+
+import com.taken_seat.performance_service.performancehall.domain.model.SeatType;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class UpdateSeatPriceDto {
+
+	private UUID performanceSeatPriceId;
+	private SeatType seatType;
+	private Integer price;
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/UpdateResponseDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/UpdateResponseDto.java
@@ -1,6 +1,7 @@
 package com.taken_seat.performance_service.performance.application.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import com.taken_seat.performance_service.performance.domain.model.PerformanceStatus;
@@ -8,18 +9,23 @@ import com.taken_seat.performance_service.performance.domain.model.PerformanceSt
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
-public class SearchResponseDto {
+@RequiredArgsConstructor
+public class UpdateResponseDto {
 
 	private UUID performanceId;
 	private String title;
+	private String description;
 	private LocalDateTime startAt;
 	private LocalDateTime endAt;
 	private PerformanceStatus status;
 	private String posterUrl;
+	private String ageLimit;
+	private Integer maxTicketCount;
+	private String discountInfo;
+	private List<PerformanceScheduleResponseDto> schedules;
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
@@ -12,9 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.taken_seat.performance_service.performance.application.dto.mapper.ResponseMapper;
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.request.SearchFilterParam;
+import com.taken_seat.performance_service.performance.application.dto.request.UpdateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.DetailResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.PageResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.UpdateResponseDto;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 import com.taken_seat.performance_service.performance.domain.repository.PerformanceRepository;
 
@@ -58,10 +60,21 @@ public class PerformanceService {
 	}
 
 	@Transactional
+	public UpdateResponseDto update(UUID id, UpdateRequestDto request) {
+
+		Performance performance = performanceRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("수정하려는 공연 정보가 존재하지 않습니다"));
+
+		performance.update(request);
+
+		return toUpdate(performance);
+	}
+
+	@Transactional
 	public void delete(UUID id, UUID deletedBy) {
 
 		if (id == null) {
-			throw new IllegalArgumentException("공연 ID는 null일 수 없습니다.");
+			throw new IllegalArgumentException("삭제할 공연 ID는 필수입니다");
 		}
 
 		performanceRepository.deleteById(id, deletedBy);

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/PerformanceSchedule.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/PerformanceSchedule.java
@@ -3,7 +3,11 @@ package com.taken_seat.performance_service.performance.domain.model;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+
+import com.taken_seat.performance_service.performance.application.dto.request.UpdatePerformanceScheduleDto;
+import com.taken_seat.performance_service.performance.application.dto.request.UpdateSeatPriceDto;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -61,4 +65,39 @@ public class PerformanceSchedule {
 	@OneToMany(mappedBy = "performanceSchedule", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Builder.Default
 	private List<PerformanceSeatPrice> seatPrices = new ArrayList<>();
+
+	public void update(UpdatePerformanceScheduleDto dto) {
+
+		if (dto.getPerformanceHallId() != null)
+			this.performanceHallId = dto.getPerformanceHallId();
+		if (dto.getStartAt() != null)
+			this.startAt = dto.getStartAt();
+		if (dto.getEndAt() != null)
+			this.endAt = dto.getEndAt();
+		if (dto.getSaleStartAt() != null)
+			this.saleStartAt = dto.getSaleStartAt();
+		if (dto.getSaleEndAt() != null)
+			this.saleEndAt = dto.getSaleEndAt();
+		if (dto.getStatus() != null)
+			this.status = dto.getStatus();
+
+		if (dto.getSeatPrices() != null) {
+			for (UpdateSeatPriceDto seatDto : dto.getSeatPrices()) {
+				Optional<PerformanceSeatPrice> match = this.seatPrices.stream()
+					.filter(savedSeatPrices -> savedSeatPrices.getId().equals(seatDto.getPerformanceSeatPriceId()))
+					.findFirst();
+
+				if (match.isPresent()) {
+					match.get().update(seatDto);
+				} else {
+					PerformanceSeatPrice newPrice = PerformanceSeatPrice.builder()
+						.performanceSchedule(this)
+						.seatType(seatDto.getSeatType())
+						.price(seatDto.getPrice())
+						.build();
+					this.seatPrices.add(newPrice);
+				}
+			}
+		}
+	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/PerformanceSeatPrice.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/PerformanceSeatPrice.java
@@ -2,6 +2,7 @@ package com.taken_seat.performance_service.performance.domain.model;
 
 import java.util.UUID;
 
+import com.taken_seat.performance_service.performance.application.dto.request.UpdateSeatPriceDto;
 import com.taken_seat.performance_service.performancehall.domain.model.SeatType;
 
 import jakarta.persistence.Column;
@@ -43,4 +44,13 @@ public class PerformanceSeatPrice {
 
 	@Column(nullable = false)
 	private Integer price;
+
+	public void update(UpdateSeatPriceDto dto) {
+
+		if (dto.getSeatType() != null)
+			this.seatType = dto.getSeatType();
+		if (dto.getPrice() != null)
+			this.price = dto.getPrice();
+	}
+
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,9 +20,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.request.SearchFilterParam;
+import com.taken_seat.performance_service.performance.application.dto.request.UpdateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.DetailResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.PageResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.UpdateResponseDto;
 import com.taken_seat.performance_service.performance.application.service.PerformanceService;
 
 import jakarta.validation.Valid;
@@ -72,10 +75,21 @@ public class PerformanceController {
 	}
 
 	/**
+	 * 공연 수정 API
+	 * 권한: ADMIN, MANAGER, PRODUCER
+	 */
+
+	@PatchMapping("/{id}")
+	public ResponseEntity<UpdateResponseDto> update(@PathVariable("id") UUID id,
+		@Valid @RequestBody UpdateRequestDto request) {
+
+		UpdateResponseDto response = performanceService.update(id, request);
+		return ResponseEntity.status(HttpStatus.OK).body(response);
+	}
+
+	/**
 	 * 공연 삭제 API
 	 * 권한: ADMIN, MANAGER, PRODUCER
-	 * Security 완성 후
-	 * @RequestParam UUID deletedBy -> @AuthenticationPrincipal CustomUserDetails principal 로 수정 예정
 	 */
 
 	@DeleteMapping("/{id}")


### PR DESCRIPTION
## 개요
공연 정보 수정 기능을 구현했습니다.  

## 작업 내용
### 변경 사항

1. 공연 수정 API 구현  
   - `PATCH /api/v1/performances/{id}`  
   - 조건부 수정 (null 체크 기반)

2. 회차(PerformanceSchedule) 수정 로직 구현  
   - `performanceScheduleId`가 있는 경우 수정, 없는 경우 신규 추가  
   - 회차 필드(startAt, endAt, status 등) 조건부 수정

3. 좌석 가격(PerformanceSeatPrice) 수정 로직 구현  
   - `performanceSeatPriceId`가 있는 경우 수정, 없는 경우 신규 추가  
   - `seatType`, `price` 수정 가능

4. 도메인 update 메서드 추가
   - `Performance#update()`, `PerformanceSchedule#update()`, `PerformanceSeatPrice#update()` 구현

5. Postman 테스트 완료
![image](https://github.com/user-attachments/assets/7ab69762-8bed-4c1d-9c86-51c66a1497dc)

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #33

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
