### PR TITLE
#91 <Booking> Ticket 생성 기능 추가

### DIFF
--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/domain/Booking.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/domain/Booking.java
@@ -40,9 +40,8 @@ public class Booking extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.UUID)
 	private UUID id;
 
-	@Builder.Default
 	@Column(nullable = false)
-	private UUID userId = UUID.randomUUID();
+	private UUID userId;
 
 	@Column(nullable = false)
 	private UUID performanceScheduleId;

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/application/dto/request/TicketCreateRequest.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/application/dto/request/TicketCreateRequest.java
@@ -1,0 +1,14 @@
+package com.taken_seat.booking_service.ticket.application.dto.request;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TicketCreateRequest {
+	private UUID bookingId;
+	private UUID performanceScheduleId;
+	private UUID seatId;
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/application/dto/response/TicketCreateResponse.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/application/dto/response/TicketCreateResponse.java
@@ -1,0 +1,20 @@
+package com.taken_seat.booking_service.ticket.application.dto.response;
+
+import java.util.UUID;
+
+import com.taken_seat.booking_service.ticket.domain.Ticket;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TicketCreateResponse {
+	private UUID id;
+
+	public static TicketCreateResponse toDto(Ticket ticket) {
+		return TicketCreateResponse.builder()
+			.id(ticket.getId())
+			.build();
+	}
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/application/messaging/TicketProducer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/application/messaging/TicketProducer.java
@@ -1,0 +1,17 @@
+package com.taken_seat.booking_service.ticket.application.messaging;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TicketProducer {
+
+	private final KafkaTemplate<String, String> kafkaTemplate;
+
+	public void sendTicketComplete(String ticketId) {
+
+	}
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/application/service/TicketService.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/application/service/TicketService.java
@@ -1,0 +1,10 @@
+package com.taken_seat.booking_service.ticket.application.service;
+
+import com.taken_seat.booking_service.common.CustomUser;
+import com.taken_seat.booking_service.ticket.application.dto.request.TicketCreateRequest;
+import com.taken_seat.booking_service.ticket.application.dto.response.TicketCreateResponse;
+
+public interface TicketService {
+	TicketCreateResponse createTicket(CustomUser customUser, TicketCreateRequest request);
+
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/domain/Ticket.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/domain/Ticket.java
@@ -35,6 +35,9 @@ public class Ticket extends BaseEntity {
 	@Column(nullable = false)
 	private UUID bookingId;
 
+	@Column(nullable = false)
+	private UUID performanceScheduleId;
+
 	@Column(length = 100)
 	private String name;
 
@@ -44,6 +47,9 @@ public class Ticket extends BaseEntity {
 	private LocalDateTime startAt;
 
 	private LocalDateTime endAt;
+
+	@Column(nullable = false)
+	private UUID seatId;
 
 	@Column(length = 10)
 	private String seatRowNumber;

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/domain/Ticket.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/domain/Ticket.java
@@ -1,0 +1,56 @@
+package com.taken_seat.booking_service.ticket.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.taken_seat.booking_service.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "p_ticket")
+public class Ticket extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	@Column(nullable = false)
+	private UUID userId;
+
+	@Column(nullable = false)
+	private UUID bookingId;
+
+	@Column(length = 100)
+	private String name;
+
+	@Column(length = 500)
+	private String address;
+
+	private LocalDateTime startAt;
+
+	private LocalDateTime endAt;
+
+	@Column(length = 10)
+	private String seatRowNumber;
+
+	@Column(length = 10)
+	private String seatNumber;
+
+	@Column(length = 10)
+	private String seatType;
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/domain/repository/TicketRepository.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/domain/repository/TicketRepository.java
@@ -1,0 +1,12 @@
+package com.taken_seat.booking_service.ticket.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.taken_seat.booking_service.ticket.domain.Ticket;
+
+@Repository
+public interface TicketRepository extends JpaRepository<Ticket, UUID> {
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/infrastructure/client/PerformanceClient.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/infrastructure/client/PerformanceClient.java
@@ -1,0 +1,7 @@
+package com.taken_seat.booking_service.ticket.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(name = "performance-service", path = "/api/v1/performances")
+public interface PerformanceClient {
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/infrastructure/messaging/TicketConsumer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/infrastructure/messaging/TicketConsumer.java
@@ -1,0 +1,22 @@
+package com.taken_seat.booking_service.ticket.infrastructure.messaging;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.taken_seat.booking_service.common.CustomUser;
+import com.taken_seat.booking_service.ticket.application.dto.request.TicketCreateRequest;
+import com.taken_seat.booking_service.ticket.application.service.TicketService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TicketConsumer {
+
+	private final TicketService ticketService;
+
+	@KafkaListener(topics = "ticket-topic", groupId = "ticket-group")
+	public void createTicket(CustomUser customUser, TicketCreateRequest request) {
+		ticketService.createTicket(customUser, request);
+	}
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/infrastructure/service/TicketServiceImpl.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/infrastructure/service/TicketServiceImpl.java
@@ -1,0 +1,33 @@
+package com.taken_seat.booking_service.ticket.infrastructure.service;
+
+import org.springframework.stereotype.Service;
+
+import com.taken_seat.booking_service.common.CustomUser;
+import com.taken_seat.booking_service.ticket.application.dto.request.TicketCreateRequest;
+import com.taken_seat.booking_service.ticket.application.dto.response.TicketCreateResponse;
+import com.taken_seat.booking_service.ticket.application.service.TicketService;
+import com.taken_seat.booking_service.ticket.domain.Ticket;
+import com.taken_seat.booking_service.ticket.domain.repository.TicketRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TicketServiceImpl implements TicketService {
+
+	private final TicketRepository ticketRepository;
+
+	@Override
+	public TicketCreateResponse createTicket(CustomUser customUser, TicketCreateRequest request) {
+
+		// TODO: FeignClient 로 공연 정보, 좌석 정보 받아오기
+		Ticket ticket = Ticket.builder()
+			.userId(customUser.getUserId())
+			.bookingId(request.getBookingId())
+			.build();
+
+		Ticket saved = ticketRepository.save(ticket);
+
+		return TicketCreateResponse.toDto(saved);
+	}
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/presentation/TicketController.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/presentation/TicketController.java
@@ -1,0 +1,32 @@
+package com.taken_seat.booking_service.ticket.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.taken_seat.booking_service.common.CustomUser;
+import com.taken_seat.booking_service.ticket.application.service.TicketService;
+import com.taken_seat.booking_service.ticket.application.dto.request.TicketCreateRequest;
+import com.taken_seat.booking_service.ticket.application.dto.response.TicketCreateResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tickets")
+public class TicketController {
+
+	private final TicketService ticketService;
+
+	@PostMapping
+	public ResponseEntity<TicketCreateResponse> createTicket(CustomUser customUser,
+		@RequestBody @Valid TicketCreateRequest request) {
+
+		TicketCreateResponse response = ticketService.createTicket(customUser, request);
+
+		return ResponseEntity.ok(response);
+	}
+}

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/request/TicketPerformanceClientRequest.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/request/TicketPerformanceClientRequest.java
@@ -1,0 +1,13 @@
+package com.taken_seat.common_service.dto.request;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TicketPerformanceClientRequest {
+	private final UUID performanceScheduleId;
+	private final UUID seatId;
+}

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/response/TicketPerformanceClientResponse.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/response/TicketPerformanceClientResponse.java
@@ -1,0 +1,16 @@
+package com.taken_seat.common_service.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TicketPerformanceClientResponse {
+	private final String startAt;
+	private final String endAt;
+	private final String name;
+	private final String address;
+	private final String seatRowNumber;
+	private final String seatNumber;
+	private final String seatType;
+}


### PR DESCRIPTION
## 개요
Ticket 생성 기능을 추가했습니다.
공연 도메인과 FeignClient 로 통신할 DTO 를 추가했습니다.
Ticket 도메인에 카프카 Producer 와 Consumer 를 준비했습니다.

## 작업 내용
1. Ticket 생성 시 공연 도메인과 FeignClient 통신 준비
2. 카프카 Producer 와 Consumer 준비
3. Common 에 FeignClient 용 DTO 생성

### 변경 사항

### 변경 이유

### 추가 설명
Booking 을 애그리거트 루트로 지정할 지, Ticket 을 별도의 도메인으로 구분할 지 고민중입니다..
## 리뷰 요구사항

#### 연관된 이슈
#91 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
