### PR TITLE
#137 Common application.properties 애플리케이션 이름 제거

### DIFF
--- a/com.taken_seat.common-service/src/main/resources/application.properties
+++ b/com.taken_seat.common-service/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=common-service


### PR DESCRIPTION
- 타 서비스를 실행시 common-service로 덮어 씌워지는 문제가 발생하여 spring.application.name= 을 제거했습니다.

## 개요
#137 Common application.properties 애플리케이션 이름 제거

## 작업 내용
### 변경 사항

### 변경 이유
- 타 서비스를 실행시 common-service로 덮어 씌워지는 문제가 발생하여 spring.application.name= 을 제거했습니다.
### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
