### PR TITLE
#154 <Performance> 공연 티켓 조회 API 공연 아이디 추가

### DIFF
--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/request/TicketPerformanceClientRequest.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/request/TicketPerformanceClientRequest.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Builder
 public class TicketPerformanceClientRequest {
 
+	private final UUID performanceId;
 	private final UUID performanceScheduleId;
 	private final UUID seatId;
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performenceticket/application/dto/mapper/RequestMapper.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performenceticket/application/dto/mapper/RequestMapper.java
@@ -6,8 +6,12 @@ import com.taken_seat.common_service.dto.request.TicketPerformanceClientRequest;
 
 public class RequestMapper {
 
-	public static TicketPerformanceClientRequest fromParams(UUID performanceScheduleId, UUID seatId) {
+	public static TicketPerformanceClientRequest fromParams(
+		UUID performanceId,
+		UUID performanceScheduleId,
+		UUID seatId) {
 		return TicketPerformanceClientRequest.builder()
+			.performanceId(performanceId)
 			.performanceScheduleId(performanceScheduleId)
 			.seatId(seatId)
 			.build();

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performenceticket/application/service/PerformenceTicketService.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performenceticket/application/service/PerformenceTicketService.java
@@ -22,8 +22,8 @@ public class PerformenceTicketService {
 
 	public TicketPerformanceClientResponse getPerformanceInfo(TicketPerformanceClientRequest request) {
 
-		Performance performance = performanceRepository.findByPerformanceScheduleId(request.getPerformanceScheduleId())
-			.orElseThrow(() -> new IllegalArgumentException("공연 회차가 존재하지 않습니다"));
+		Performance performance = performanceRepository.findById(request.getPerformanceId())
+			.orElseThrow(() -> new IllegalArgumentException("공연 정보가 존재하지 않습니다"));
 
 		PerformanceSchedule schedule = performance.getScheduleById(request.getPerformanceScheduleId());
 

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performenceticket/presentation/controller/PerformenceTicketController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performenceticket/presentation/controller/PerformenceTicketController.java
@@ -23,7 +23,7 @@ public class PerformenceTicketController {
 
 	private final PerformenceTicketService performenceTicketService;
 
-	@GetMapping("/{performanceId}/{performanceScheduleId}/seats/{seatId}")
+	@GetMapping("/{performanceId}/schedules/{performanceScheduleId}/seats/{seatId}")
 	public ResponseEntity<TicketPerformanceClientResponse> getPerformanceInfo(
 		@PathVariable UUID performanceId,
 		@PathVariable UUID performanceScheduleId,

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performenceticket/presentation/controller/PerformenceTicketController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performenceticket/presentation/controller/PerformenceTicketController.java
@@ -23,12 +23,13 @@ public class PerformenceTicketController {
 
 	private final PerformenceTicketService performenceTicketService;
 
-	@GetMapping("/{performanceScheduleId}/seats/{seatId}")
+	@GetMapping("/{performanceId}/{performanceScheduleId}/seats/{seatId}")
 	public ResponseEntity<TicketPerformanceClientResponse> getPerformanceInfo(
+		@PathVariable UUID performanceId,
 		@PathVariable UUID performanceScheduleId,
 		@PathVariable UUID seatId) {
 
-		TicketPerformanceClientRequest request = RequestMapper.fromParams(performanceScheduleId, seatId);
+		TicketPerformanceClientRequest request = RequestMapper.fromParams(performanceId, performanceScheduleId, seatId);
 
 		TicketPerformanceClientResponse response = performenceTicketService.getPerformanceInfo(request);
 		return ResponseEntity.status(HttpStatus.OK).body(response);


### PR DESCRIPTION
## 개요
공연 티켓 조회 API에 공연 아이디(`performanceId`)를 추가하여 공연 회차와 좌석 정보를 조회하도록 수정

## 작업 내용
### 변경 사항

- `TicketPerformanceClientRequest`에 공연 아이디(`performanceId`) 필드 추가
- 공연 정보 조회 시 공연 아이디를 사용하여 해당 공연의 회차 정보 조회
- 기존 로직을 유지하면서 공연 아이디를 통해 조회하도록 수정
- 테스트 완료
![image](https://github.com/user-attachments/assets/1475afba-a151-4414-a953-a87c52b0b65a)


### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #154 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
