### PR TITLE
#151 <Performance> 공연 종료 시간 조회 API 구현

### DIFF
--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/PerformanceEndTimeDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/dto/response/PerformanceEndTimeDto.java
@@ -1,0 +1,6 @@
+package com.taken_seat.performance_service.performance.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record PerformanceEndTimeDto(LocalDateTime endAt) {
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
@@ -16,8 +16,10 @@ import com.taken_seat.performance_service.performance.application.dto.request.Up
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.DetailResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.PageResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.PerformanceEndTimeDto;
 import com.taken_seat.performance_service.performance.application.dto.response.UpdateResponseDto;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
+import com.taken_seat.performance_service.performance.domain.model.PerformanceSchedule;
 import com.taken_seat.performance_service.performance.domain.repository.PerformanceRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -78,5 +80,15 @@ public class PerformanceService {
 		}
 
 		performanceRepository.deleteById(id, deletedBy);
+	}
+
+	@Transactional
+	public PerformanceEndTimeDto getPerformanceEndTime(UUID performanceId, UUID performanceScheduleId) {
+		Performance performance = performanceRepository.findById(performanceId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 공연이 존재하지 않습니다."));
+
+		PerformanceSchedule schedule = performance.getScheduleById(performanceScheduleId);
+
+		return new PerformanceEndTimeDto(schedule.getEndAt());
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
@@ -18,12 +18,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.taken_seat.common_service.dto.ApiResponseData;
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.request.SearchFilterParam;
 import com.taken_seat.performance_service.performance.application.dto.request.UpdateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.response.CreateResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.DetailResponseDto;
 import com.taken_seat.performance_service.performance.application.dto.response.PageResponseDto;
+import com.taken_seat.performance_service.performance.application.dto.response.PerformanceEndTimeDto;
 import com.taken_seat.performance_service.performance.application.dto.response.UpdateResponseDto;
 import com.taken_seat.performance_service.performance.application.service.PerformanceService;
 
@@ -97,5 +99,19 @@ public class PerformanceController {
 
 		performanceService.delete(id, deletedBy);
 		return ResponseEntity.noContent().build();
+	}
+
+	/**
+	 * 공연 종료 시간 조회 API
+	 * 리뷰 등록하기 전 해당 공연이 종료되었는지 검사하기 위해 종료시간을 받아오는 메서드
+	 */
+
+	@GetMapping("/{performanceId}/schedules/{performanceScheduleId}/end-time")
+	ResponseEntity<ApiResponseData<PerformanceEndTimeDto>> getPerformanceEndTime(
+		@PathVariable("performanceId") UUID performanceId,
+		@PathVariable("performanceScheduleId") UUID performanceScheduleId) {
+
+		PerformanceEndTimeDto response = performanceService.getPerformanceEndTime(performanceId, performanceScheduleId);
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseData.success(response));
 	}
 }


### PR DESCRIPTION
## 개요
- 공연 회차 종료 시간을 조회하는 API 구현
- 리뷰 작성 전, 해당 공연이 종료되었는지를 판단하기 위한 목적으로 사용됩니다.

## 작업 내용
### 변경 사항

1. **Controller**
   - GET /{performanceId}/schedules/{performanceScheduleId}/end-time 엔드포인트 추가

2. **Service**
   - performanceId를 기준으로 공연을 조회
   - 공연 내부에서 performanceScheduleId에 해당하는 회차를 찾아 종료 시간 반환

3. **DTO**
   - `PerformanceEndTimeDto` 레코드 생성
   - 회차 종료 시간(endAt) 반환을 위한 응답 전용 DTO

4. **테스트**
![image](https://github.com/user-attachments/assets/886e01b3-9b20-4135-b0f6-8fde33aa2c70)


### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #151 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
