### PR TITLE
#127 <Review> 좋아요 수 토글 기능

### DIFF
--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/entity/BaseTimeEntity.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/entity/BaseTimeEntity.java
@@ -19,22 +19,22 @@ public abstract class BaseTimeEntity {
 
 	@CreatedDate
 	@Column(updatable = false, nullable = false)
-	private LocalDateTime createdAt;
+	protected LocalDateTime createdAt;
 
 	@Column(updatable = false, nullable = false)
-	private UUID createdBy;
+	protected UUID createdBy;
 
 	@LastModifiedDate
-	private LocalDateTime updatedAt;
+	protected LocalDateTime updatedAt;
 
 	@Column
-	private UUID updatedBy;
+	protected UUID updatedBy;
 
 	@Column
-	private LocalDateTime deletedAt;
+	protected LocalDateTime deletedAt;
 
 	@Column
-	private UUID deletedBy;
+	protected UUID deletedBy;
 
 	public void delete(UUID deleteBy) {
 		this.deletedBy = deleteBy;

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/exception/enums/ResponseCode.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/exception/enums/ResponseCode.java
@@ -52,6 +52,7 @@ public enum ResponseCode {
 	FORBIDDEN_REVIEW_ACCESS(HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN.value(), "해당 리뷰에 접근할 권한이 없습니다."),
 	BOOKING_NOT_COMPLETED(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.value(), "예매가 완료된 공연에 대해서만 리뷰를 작성할 수 있습니다."),
 	EARLY_REVIEW(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.value(), "공연 시작 전에는 리뷰를 등록할 수 없습니다."),
+	INVALID_LIKE_COUNT(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.value(), "좋아요 수는 0보다 작을 수 없습니다."),
 
 	// Performance
 	PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당 공연 정보를 찾을 수 없습니다."),
@@ -64,12 +65,13 @@ public enum ResponseCode {
 	BOOKING_ALREADY_CANCELED_EXCEPTION(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "이미 취소된 예약입니다."),
 	BOOKING_NOT_CANCELED_EXCEPTION(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "예약 취소 후 삭제할 수 있습니다."),
 	BOOKING_SEAT_LOCKED_EXCEPTION(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "이미 선점된 좌석입니다."),
-	BOOKING_INTERRUPTED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.value(), "인터럽트가 발생했습니다."),
-    
-  // Performance
+	BOOKING_INTERRUPTED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.value(),
+		"인터럽트가 발생했습니다."),
+
+	// Performance
 	PERFORMANCE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당 공연은 존재하지 않습니다"),
-	PERFORMANCE_VALIDATION_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "동일 공연장에 겹치는 회차가 존재합니다.");  
-   
+	PERFORMANCE_VALIDATION_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "동일 공연장에 겹치는 회차가 존재합니다.");
+
 	private final HttpStatus status;
 	private final Integer code;
 	private final String message;

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/ReviewServiceApplication.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/ReviewServiceApplication.java
@@ -3,12 +3,14 @@ package com.taken_seat.review_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = {
 	"com.taken_seat.review_service",
 	"com.taken_seat.common_service"
 })
 @EnableFeignClients
+@EnableScheduling
 public class ReviewServiceApplication {
 
 	public static void main(String[] args) {

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewLikeScheduler.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewLikeScheduler.java
@@ -1,0 +1,50 @@
+package com.taken_seat.review_service.application.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.taken_seat.review_service.domain.model.Review;
+import com.taken_seat.review_service.domain.repository.ReviewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewLikeScheduler {
+
+	private final ReviewLikeService reviewLikeService;
+	private final ReviewRepository reviewRepository;
+	
+	@Scheduled(cron = "0 */5 * * * ?")  // 매 5분마다 실행
+	public void updateReviewLikeCounts() {
+		// Redis에서 모든 리뷰와 좋아요 수를 가져옴 (Hash 형태로)
+		Map<String, Integer> reviewLikesMap = reviewLikeService.getAllReviewIdsWithLikes();
+
+		// 저장할 리뷰 목록을 준비
+		List<Review> reviewsToUpdate = new ArrayList<>();
+
+		// 가져온 리뷰와 좋아요 수에 대해 DB 업데이트
+		reviewLikesMap.forEach((reviewId, likeCount) -> {
+			UUID reviewUUID = UUID.fromString(reviewId);  // Redis에서 가져온 String을 UUID로 변환
+
+			// DB에서 해당 리뷰를 찾아 좋아요 수 업데이트
+			reviewRepository.findByIdAndDeletedAtIsNull(reviewUUID).ifPresent(review -> {
+				review.updateLikeCount(likeCount);
+				reviewsToUpdate.add(review);  // 업데이트된 리뷰를 리스트에 추가
+			});
+		});
+
+		// 모든 리뷰를 일괄적으로 DB에 저장
+		if (!reviewsToUpdate.isEmpty()) {
+			reviewRepository.saveAllAndFlush(reviewsToUpdate);
+			reviewLikeService.deleteAllReviewLikeKeys(reviewLikesMap);
+		}
+
+	}
+
+}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewLikeService.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewLikeService.java
@@ -35,6 +35,14 @@ public class ReviewLikeService {
 		if (reviewLikeOpt.isEmpty()) {
 			reviewLikeRepository.save(ReviewLike.create(review, authenticatedUser.getUserId()));
 			review.updateLikeCount(1);
+		} else if (reviewLikeOpt.get().isDeleted()) {
+			
+			reviewLikeOpt.get().addReviewLike(authenticatedUser.getUserId());
+			review.updateLikeCount(1);
+		} else {
+			// 이미 좋아요가 눌려있으면 취소
+			reviewLikeOpt.get().cancelReviewLike(authenticatedUser.getUserId());
+			review.updateLikeCount(-1);
 		}
 
 	}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewLikeService.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewLikeService.java
@@ -1,49 +1,20 @@
 package com.taken_seat.review_service.application.service;
 
-import java.util.Optional;
+import java.util.Map;
 import java.util.UUID;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.taken_seat.common_service.dto.AuthenticatedUser;
-import com.taken_seat.common_service.exception.customException.ReviewException;
-import com.taken_seat.common_service.exception.enums.ResponseCode;
-import com.taken_seat.review_service.domain.model.Review;
-import com.taken_seat.review_service.domain.model.ReviewLike;
-import com.taken_seat.review_service.domain.repository.ReviewLikeRepository;
-import com.taken_seat.review_service.domain.repository.ReviewRepository;
 
-import lombok.RequiredArgsConstructor;
+public interface ReviewLikeService {
 
-@Service
-@RequiredArgsConstructor
-@Transactional
-public class ReviewLikeService {
+	void toggleReviewLike(UUID id, AuthenticatedUser authenticatedUser);
 
-	private final ReviewLikeRepository reviewLikeRepository;
-	private final ReviewRepository reviewRepository;
+	void increaseLikeCount(String key);
 
-	public void toggleReviewLike(UUID id, AuthenticatedUser authenticatedUser) {
+	void decreaseLikeCount(String key);
 
-		Review review = reviewRepository.findWithPessimisticLockById(id)
-			.orElseThrow(() -> new ReviewException(ResponseCode.REVIEW_NOT_FOUND));
+	Map<String, Integer> getAllReviewIdsWithLikes();
 
-		Optional<ReviewLike> reviewLikeOpt = reviewLikeRepository.findByAuthorIdAndReviewId(
-			authenticatedUser.getUserId(), id);
+	void deleteAllReviewLikeKeys(Map<String, Integer> reviewLikesMap);
 
-		if (reviewLikeOpt.isEmpty()) {
-			reviewLikeRepository.save(ReviewLike.create(review, authenticatedUser.getUserId()));
-			review.updateLikeCount(1);
-		} else if (reviewLikeOpt.get().isDeleted()) {
-			
-			reviewLikeOpt.get().addReviewLike(authenticatedUser.getUserId());
-			review.updateLikeCount(1);
-		} else {
-			// 이미 좋아요가 눌려있으면 취소
-			reviewLikeOpt.get().cancelReviewLike(authenticatedUser.getUserId());
-			review.updateLikeCount(-1);
-		}
-
-	}
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewLikeService.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewLikeService.java
@@ -1,0 +1,41 @@
+package com.taken_seat.review_service.application.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.taken_seat.common_service.dto.AuthenticatedUser;
+import com.taken_seat.common_service.exception.customException.ReviewException;
+import com.taken_seat.common_service.exception.enums.ResponseCode;
+import com.taken_seat.review_service.domain.model.Review;
+import com.taken_seat.review_service.domain.model.ReviewLike;
+import com.taken_seat.review_service.domain.repository.ReviewLikeRepository;
+import com.taken_seat.review_service.domain.repository.ReviewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewLikeService {
+
+	private final ReviewLikeRepository reviewLikeRepository;
+	private final ReviewRepository reviewRepository;
+
+	public void toggleReviewLike(UUID id, AuthenticatedUser authenticatedUser) {
+
+		Review review = reviewRepository.findWithPessimisticLockById(id)
+			.orElseThrow(() -> new ReviewException(ResponseCode.REVIEW_NOT_FOUND));
+
+		Optional<ReviewLike> reviewLikeOpt = reviewLikeRepository.findByAuthorIdAndReviewId(
+			authenticatedUser.getUserId(), id);
+
+		if (reviewLikeOpt.isEmpty()) {
+			reviewLikeRepository.save(ReviewLike.create(review, authenticatedUser.getUserId()));
+			review.updateLikeCount(1);
+		}
+
+	}
+}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewService.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewService.java
@@ -1,135 +1,24 @@
 package com.taken_seat.review_service.application.service;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.CachePut;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.cache.annotation.Caching;
-import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.taken_seat.common_service.dto.AuthenticatedUser;
-import com.taken_seat.common_service.exception.customException.ReviewException;
-import com.taken_seat.common_service.exception.enums.ResponseCode;
-import com.taken_seat.review_service.application.client.ReviewClient;
 import com.taken_seat.review_service.application.dto.request.ReviewRegisterReqDto;
 import com.taken_seat.review_service.application.dto.request.ReviewUpdateReqDto;
 import com.taken_seat.review_service.application.dto.response.PageReviewResponseDto;
 import com.taken_seat.review_service.application.dto.response.ReviewDetailResDto;
-import com.taken_seat.review_service.domain.model.Review;
-import com.taken_seat.review_service.domain.repository.ReviewQuerydslRepository;
-import com.taken_seat.review_service.domain.repository.ReviewRepository;
-import com.taken_seat.review_service.infrastructure.client.dto.PerformanceEndTimeDto;
 
-import feign.FeignException;
-import lombok.RequiredArgsConstructor;
+public interface ReviewService {
 
-@Service
-@RequiredArgsConstructor
-@Transactional
-public class ReviewService {
+	ReviewDetailResDto registerReview(ReviewRegisterReqDto requestDto, AuthenticatedUser authenticatedUser);
 
-	private final ReviewRepository reviewRepository;
-	private final ReviewQuerydslRepository reviewQuerydslRepository;
-	private final ReviewClient reviewClient;
+	ReviewDetailResDto getReviewDetail(UUID id);
 
-	@CachePut(cacheNames = "reviewCache", key = "#result.id")
-	public ReviewDetailResDto registerReview(ReviewRegisterReqDto requestDto, AuthenticatedUser authenticatedUser) {
-		// 1. 리뷰 중복 작성 방지
-		if (reviewRepository.existsByAuthorIdAndPerformanceId(authenticatedUser.getUserId(),
-			requestDto.getPerformanceId())) {
-			throw new ReviewException(ResponseCode.REVIEW_ALREADY_WRITTEN);
-		}
+	PageReviewResponseDto searchReview(String q, String category, int page, int size, String sort,
+		String order);
 
-		// 2. 예매 상태 확인
-		try {
-			String status = reviewClient.getBookingStatus(authenticatedUser.getUserId(), requestDto.getPerformanceId())
-				.status();
-			if (!"COMPLETED".equals(status)) {
-				throw new ReviewException(ResponseCode.BOOKING_NOT_COMPLETED);
-			}
-		} catch (FeignException.Forbidden e) {
-			throw new ReviewException(ResponseCode.BOOKING_NOT_COMPLETED);
-		}
+	ReviewDetailResDto updateReview(UUID id, ReviewUpdateReqDto reviewUpdateReqDto,
+		AuthenticatedUser authenticatedUser);
 
-		// 3. 공연 종료 여부 확인
-		try {
-			PerformanceEndTimeDto perInfo = reviewClient.getPerformanceEndTime(requestDto.getPerformanceId(),
-				requestDto.getPerformanceScheduleId());
-			if (LocalDateTime.now().isBefore(perInfo.endAt())) {
-				throw new ReviewException(ResponseCode.EARLY_REVIEW);
-			}
-		} catch (FeignException.NotFound e) {
-			throw new ReviewException(ResponseCode.PERFORMANCE_NOT_FOUND);
-		}
-
-		// 4. 리뷰 생성 및 저장
-		Review review = Review.create(requestDto, authenticatedUser);
-		reviewRepository.save(review);
-
-		return ReviewDetailResDto.toResponse(review);
-	}
-
-	@Transactional(readOnly = true)
-	@CachePut(cacheNames = "reviewCache", key = "#id")
-	public ReviewDetailResDto getReviewDetail(UUID id) {
-
-		Review review = reviewRepository.findByIdAndDeletedAtIsNull(id)
-			.orElseThrow(() -> new ReviewException(ResponseCode.REVIEW_NOT_FOUND));
-
-		return ReviewDetailResDto.toResponse(review);
-	}
-
-	@Transactional(readOnly = true)
-	@Cacheable(cacheNames = "reviewSearchCache", key = "#q + '-' + #category + '-' + #page + '-' + #size")
-	public PageReviewResponseDto searchReview(String q, String category, int page, int size, String sort,
-		String order) {
-
-		Page<Review> reviewPages = reviewQuerydslRepository.search(q, category, page, size, sort, order);
-
-		Page<ReviewDetailResDto> reviewDetailResDtoPages = reviewPages.map(ReviewDetailResDto::toResponse);
-
-		return PageReviewResponseDto.toResponse(reviewDetailResDtoPages);
-	}
-
-	@CachePut(cacheNames = "reviewCache", key = "#id")
-	@CacheEvict(cacheNames = "reviewSearchCache", allEntries = true)
-	public ReviewDetailResDto updateReview(UUID id, ReviewUpdateReqDto reviewUpdateReqDto,
-		AuthenticatedUser authenticatedUser) {
-
-		Review review = reviewRepository.findByIdAndDeletedAtIsNull(id)
-			.orElseThrow(() -> new ReviewException(ResponseCode.REVIEW_NOT_FOUND));
-
-		validateAccessAuthority(review, authenticatedUser);
-
-		review.update(reviewUpdateReqDto, authenticatedUser);
-
-		return ReviewDetailResDto.toResponse(review);
-	}
-
-	@Caching(evict = {
-		@CacheEvict(cacheNames = "reviewCache", key = "#id"),
-		@CacheEvict(cacheNames = "reviewSearchCache", key = "#id")
-	})
-	public void deleteReview(UUID id, AuthenticatedUser authenticatedUser) {
-
-		Review review = reviewRepository.findByIdAndDeletedAtIsNull(id)
-			.orElseThrow(() -> new ReviewException(ResponseCode.REVIEW_NOT_FOUND));
-
-		validateAccessAuthority(review, authenticatedUser);
-
-		review.delete(authenticatedUser.getUserId());
-	}
-
-	private void validateAccessAuthority(Review review, AuthenticatedUser authenticatedUser) {
-		boolean isAuthor = review.getAuthorId().equals(authenticatedUser.getUserId());
-		boolean isMaster = "MASTER".equals(authenticatedUser.getRole());
-
-		if (!(isAuthor || isMaster)) {
-			throw new ReviewException(ResponseCode.FORBIDDEN_REVIEW_ACCESS);
-		}
-	}
+	void deleteReview(UUID id, AuthenticatedUser authenticatedUser);
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/model/Review.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/model/Review.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 import com.taken_seat.common_service.dto.AuthenticatedUser;
 import com.taken_seat.common_service.entity.BaseTimeEntity;
+import com.taken_seat.common_service.exception.customException.ReviewException;
+import com.taken_seat.common_service.exception.enums.ResponseCode;
 import com.taken_seat.review_service.application.dto.request.ReviewRegisterReqDto;
 import com.taken_seat.review_service.application.dto.request.ReviewUpdateReqDto;
 
@@ -73,5 +75,13 @@ public class Review extends BaseTimeEntity {
 		this.title = reviewUpdateReqDto.getTitle();
 		this.content = reviewUpdateReqDto.getContent();
 		this.preUpdate(authenticatedUser.getUserId());
+	}
+
+	public void updateLikeCount(int i) {
+		int newCnt = this.likeCount + i;
+		if (newCnt < 0) {
+			throw new ReviewException(ResponseCode.INVALID_LIKE_COUNT);
+		}
+		this.likeCount = newCnt;
 	}
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/model/ReviewLike.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/model/ReviewLike.java
@@ -1,0 +1,52 @@
+package com.taken_seat.review_service.domain.model;
+
+import java.util.UUID;
+
+import com.taken_seat.common_service.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "p_review_like")
+public class ReviewLike extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(columnDefinition = "BINARY(16)", updatable = false, nullable = false, length = 36)
+	private UUID id;
+
+	@Column(nullable = false)
+	private UUID authorId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "review_id")
+	private Review review;
+
+	public static ReviewLike create(Review review, UUID userId) {
+
+		ReviewLike reviewLike = ReviewLike.builder()
+			.authorId(userId)
+			.review(review)
+			.build();
+
+		reviewLike.prePersist(userId);
+
+		return reviewLike;
+	}
+}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/model/ReviewLike.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/model/ReviewLike.java
@@ -3,6 +3,8 @@ package com.taken_seat.review_service.domain.model;
 import java.util.UUID;
 
 import com.taken_seat.common_service.entity.BaseTimeEntity;
+import com.taken_seat.common_service.exception.customException.ReviewException;
+import com.taken_seat.common_service.exception.enums.ResponseCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -48,5 +50,28 @@ public class ReviewLike extends BaseTimeEntity {
 		reviewLike.prePersist(userId);
 
 		return reviewLike;
+	}
+
+	public boolean isDeleted() {
+		return this.getDeletedAt() != null;
+	}
+
+	public void addReviewLike(UUID authorId) {
+		validateOwner(authorId);
+		this.deletedAt = null;
+		this.preUpdate(authorId);
+
+	}
+
+	public void cancelReviewLike(UUID authorId) {
+		validateOwner(authorId);
+		this.delete(authorId);
+		this.preUpdate(authorId);
+	}
+
+	private void validateOwner(UUID authorId) {
+		if (!this.authorId.equals(authorId)) {
+			throw new ReviewException(ResponseCode.FORBIDDEN_REVIEW_ACCESS);
+		}
 	}
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/repository/ReviewLikeRepository.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/repository/ReviewLikeRepository.java
@@ -1,0 +1,16 @@
+package com.taken_seat.review_service.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.taken_seat.review_service.domain.model.ReviewLike;
+
+@Repository
+public interface ReviewLikeRepository {
+
+	Optional<ReviewLike> findByAuthorIdAndReviewId(UUID authorId, UUID reviewId);
+
+	ReviewLike save(ReviewLike reviewLike);
+}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/repository/ReviewRepository.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/repository/ReviewRepository.java
@@ -1,15 +1,12 @@
 package com.taken_seat.review_service.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.taken_seat.review_service.domain.model.Review;
-
-import jakarta.persistence.LockModeType;
 
 @Repository
 public interface ReviewRepository {
@@ -20,8 +17,6 @@ public interface ReviewRepository {
 
 	Optional<Review> findByIdAndDeletedAtIsNull(UUID id);
 
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("SELECT r FROM Review r WHERE r.id = :id AND r.deletedAt IS NULL ")
-	Optional<Review> findWithPessimisticLockById(UUID id);
+	<S extends Review> List<S> saveAllAndFlush(Iterable<S> entities);
 
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/repository/ReviewRepository.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/repository/ReviewRepository.java
@@ -3,17 +3,25 @@ package com.taken_seat.review_service.domain.repository;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.taken_seat.review_service.domain.model.Review;
 
+import jakarta.persistence.LockModeType;
+
 @Repository
 public interface ReviewRepository {
-	
+
 	Review save(Review review);
 
 	Boolean existsByAuthorIdAndPerformanceId(UUID authorId, UUID performanceId);
 
 	Optional<Review> findByIdAndDeletedAtIsNull(UUID id);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT r FROM Review r WHERE r.id = :id AND r.deletedAt IS NULL ")
+	Optional<Review> findWithPessimisticLockById(UUID id);
 
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/config/redis/RedisTemplateConfig.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/config/redis/RedisTemplateConfig.java
@@ -1,0 +1,44 @@
+package com.taken_seat.review_service.infrastructure.config.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisTemplateConfig {
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+		// key, hashKey는 String 타입으로 저장
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+		// value, hashValue는 JSON 직렬화로 저장
+		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+		return redisTemplate;
+	}
+
+	@Bean
+	public RedisTemplate<String, Integer> likeCountRedisTemplate(RedisConnectionFactory factory) {
+		RedisTemplate<String, Integer> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(factory);
+
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+		// Integer 타입도 JSON으로 직렬화 (또는 적절한 Integer 전용 serializer 사용 가능)
+		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+		return redisTemplate;
+	}
+
+}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/repository/JpaReviewLikeRepository.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/repository/JpaReviewLikeRepository.java
@@ -1,0 +1,11 @@
+package com.taken_seat.review_service.infrastructure.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.taken_seat.review_service.domain.model.ReviewLike;
+import com.taken_seat.review_service.domain.repository.ReviewLikeRepository;
+
+public interface JpaReviewLikeRepository extends JpaRepository<ReviewLike, UUID>, ReviewLikeRepository {
+}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/service/ReviewLikeServiceImpl.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/service/ReviewLikeServiceImpl.java
@@ -1,0 +1,138 @@
+package com.taken_seat.review_service.infrastructure.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.taken_seat.common_service.dto.AuthenticatedUser;
+import com.taken_seat.review_service.application.service.ReviewLikeService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewLikeServiceImpl implements ReviewLikeService {
+
+	private final RedisTemplate<String, Integer> likeCountRedisTemplate;
+
+	private static final String LIKE_KEY_PREFIX = "review:like:";
+	private static final String USER_FIELD_PREFIX = "user:";
+
+	private HashOperations<String, String, Object> hashOps;
+
+	@Override
+	public void toggleReviewLike(UUID id, AuthenticatedUser authenticatedUser) {
+		hashOps = likeCountRedisTemplate.opsForHash();
+		String key = getRedisKey(id);
+		String userField = getUserField(authenticatedUser.getUserId());
+
+		boolean hasLiked = hashOps.hasKey(key, userField);
+
+		if (hasLiked) {
+			// 이미 좋아요를 누른 경우
+			hashOps.delete(key, userField);
+			decreaseLikeCount(key);
+
+		} else {
+			// 좋아요 추가
+			hashOps.put(key, userField, true);
+			increaseLikeCount(key);
+		}
+
+	}
+
+	// 아래 두 메서드는 주기적인 스케줄러에서 DB에 반영할 때 호출
+	@Override
+	public void increaseLikeCount(String key) {
+		hashOps.increment(key, "count", 1);
+	}
+
+	@Override
+	public void decreaseLikeCount(String key) {
+		hashOps.increment(key, "count", -1);  // -1을 넘기면 감소
+	}
+
+	// Redis에서 모든 리뷰의 좋아요 수를 가져와 HashMap으로 반환
+	@Override
+	public Map<String, Integer> getAllReviewIdsWithLikes() {
+		hashOps = likeCountRedisTemplate.opsForHash();
+		String pattern = "review:like:*";
+
+		RedisConnection connection = likeCountRedisTemplate.getConnectionFactory().getConnection();
+		ScanOptions options = ScanOptions.scanOptions()
+			.match(pattern)
+			.count(1000)  // 한 번에 가져올 키 개수
+			.build();
+
+		// SCAN을 통해 Redis에서 키를 가져옴
+		Cursor<byte[]> keys = connection.scan(options);
+
+		// 결과를 저장할 맵
+		Map<String, Integer> reviewLikesMap = new HashMap<>();
+
+		// SCAN을 통해 가져온 키들에 대해 처리
+		while (keys.hasNext()) {
+			// Redis에서 가져온 키 (byte[])를 문자열로 변환
+			String key = new String(keys.next());
+
+			// Redis에서 해당 키에 대한 좋아요 수를 가져옴
+			Integer likeCount = getLikeCountFromRedis(key);
+
+			// UUID 만 분리
+			key = key.replace(LIKE_KEY_PREFIX, "");
+
+			// reviewLikesMap에 키와 좋아요 수를 추가
+			reviewLikesMap.put(key, likeCount);
+		}
+
+		// SCAN이 끝난 후, 연결 자원을 닫음
+		connection.close();
+		return reviewLikesMap;
+	}
+
+	@Override
+	public void deleteAllReviewLikeKeys(Map<String, Integer> reviewLikesMap) {
+		if (reviewLikesMap.isEmpty())
+			return;
+
+		// Redis에 실제 저장된 키 형식으로 복원
+		List<String> redisKeys = reviewLikesMap.keySet().stream()
+			.map(id -> LIKE_KEY_PREFIX + id)
+			.toList();
+
+		// Redis에서 해당 키들 삭제
+		likeCountRedisTemplate.delete(redisKeys);
+	}
+
+	// Redis에서 특정 키에 대한 좋아요 수를 가져오는 메서드
+	private Integer getLikeCountFromRedis(String key) {
+		hashOps = likeCountRedisTemplate.opsForHash();
+
+		Integer count = (Integer)hashOps.get(key, "count");
+
+		// "count" 값이 있으면 Integer로 변환하여 반환, 없으면 기본값 0 반환
+		if (count != null) {
+			return count;
+		} else {
+			return 0; // 기본값 0 반환
+		}
+	}
+
+	private String getRedisKey(UUID reviewId) {
+		return LIKE_KEY_PREFIX + reviewId;
+	}
+
+	private String getUserField(UUID userId) {
+		return USER_FIELD_PREFIX + userId;
+	}
+}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/service/ReviewServiceImpl.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/service/ReviewServiceImpl.java
@@ -1,0 +1,141 @@
+package com.taken_seat.review_service.infrastructure.service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.taken_seat.common_service.dto.AuthenticatedUser;
+import com.taken_seat.common_service.exception.customException.ReviewException;
+import com.taken_seat.common_service.exception.enums.ResponseCode;
+import com.taken_seat.review_service.application.client.ReviewClient;
+import com.taken_seat.review_service.application.dto.request.ReviewRegisterReqDto;
+import com.taken_seat.review_service.application.dto.request.ReviewUpdateReqDto;
+import com.taken_seat.review_service.application.dto.response.PageReviewResponseDto;
+import com.taken_seat.review_service.application.dto.response.ReviewDetailResDto;
+import com.taken_seat.review_service.application.service.ReviewService;
+import com.taken_seat.review_service.domain.model.Review;
+import com.taken_seat.review_service.domain.repository.ReviewQuerydslRepository;
+import com.taken_seat.review_service.domain.repository.ReviewRepository;
+import com.taken_seat.review_service.infrastructure.client.dto.PerformanceEndTimeDto;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewServiceImpl implements ReviewService {
+
+	private final ReviewRepository reviewRepository;
+	private final ReviewQuerydslRepository reviewQuerydslRepository;
+	private final ReviewClient reviewClient;
+
+	@Override
+	@CachePut(cacheNames = "reviewCache", key = "#result.id")
+	public ReviewDetailResDto registerReview(ReviewRegisterReqDto requestDto, AuthenticatedUser authenticatedUser) {
+		// 1. 리뷰 중복 작성 방지
+		if (reviewRepository.existsByAuthorIdAndPerformanceId(authenticatedUser.getUserId(),
+			requestDto.getPerformanceId())) {
+			throw new ReviewException(ResponseCode.REVIEW_ALREADY_WRITTEN);
+		}
+
+		// 2. 예매 상태 확인
+		try {
+			String status = reviewClient.getBookingStatus(authenticatedUser.getUserId(), requestDto.getPerformanceId())
+				.status();
+			if (!"COMPLETED".equals(status)) {
+				throw new ReviewException(ResponseCode.BOOKING_NOT_COMPLETED);
+			}
+		} catch (FeignException.Forbidden e) {
+			throw new ReviewException(ResponseCode.BOOKING_NOT_COMPLETED);
+		}
+
+		// 3. 공연 종료 여부 확인
+		try {
+			PerformanceEndTimeDto perInfo = reviewClient.getPerformanceEndTime(requestDto.getPerformanceId(),
+				requestDto.getPerformanceScheduleId());
+			if (LocalDateTime.now().isBefore(perInfo.endAt())) {
+				throw new ReviewException(ResponseCode.EARLY_REVIEW);
+			}
+		} catch (FeignException.NotFound e) {
+			throw new ReviewException(ResponseCode.PERFORMANCE_NOT_FOUND);
+		}
+
+		// 4. 리뷰 생성 및 저장
+		Review review = Review.create(requestDto, authenticatedUser);
+		reviewRepository.save(review);
+
+		return ReviewDetailResDto.toResponse(review);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	@CachePut(cacheNames = "reviewCache", key = "#id")
+	public ReviewDetailResDto getReviewDetail(UUID id) {
+
+		Review review = reviewRepository.findByIdAndDeletedAtIsNull(id)
+			.orElseThrow(() -> new ReviewException(ResponseCode.REVIEW_NOT_FOUND));
+
+		return ReviewDetailResDto.toResponse(review);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	@Cacheable(cacheNames = "reviewSearchCache", key = "#q + '-' + #category + '-' + #page + '-' + #size")
+	public PageReviewResponseDto searchReview(String q, String category, int page, int size, String sort,
+		String order) {
+
+		Page<Review> reviewPages = reviewQuerydslRepository.search(q, category, page, size, sort, order);
+
+		Page<ReviewDetailResDto> reviewDetailResDtoPages = reviewPages.map(ReviewDetailResDto::toResponse);
+
+		return PageReviewResponseDto.toResponse(reviewDetailResDtoPages);
+	}
+
+	@Override
+	@CachePut(cacheNames = "reviewCache", key = "#id")
+	@CacheEvict(cacheNames = "reviewSearchCache", allEntries = true)
+	public ReviewDetailResDto updateReview(UUID id, ReviewUpdateReqDto reviewUpdateReqDto,
+		AuthenticatedUser authenticatedUser) {
+
+		Review review = reviewRepository.findByIdAndDeletedAtIsNull(id)
+			.orElseThrow(() -> new ReviewException(ResponseCode.REVIEW_NOT_FOUND));
+
+		validateAccessAuthority(review, authenticatedUser);
+
+		review.update(reviewUpdateReqDto, authenticatedUser);
+
+		return ReviewDetailResDto.toResponse(review);
+	}
+
+	@Override
+	@Caching(evict = {
+		@CacheEvict(cacheNames = "reviewCache", key = "#id"),
+		@CacheEvict(cacheNames = "reviewSearchCache", key = "#id")
+	})
+	public void deleteReview(UUID id, AuthenticatedUser authenticatedUser) {
+
+		Review review = reviewRepository.findByIdAndDeletedAtIsNull(id)
+			.orElseThrow(() -> new ReviewException(ResponseCode.REVIEW_NOT_FOUND));
+
+		validateAccessAuthority(review, authenticatedUser);
+
+		review.delete(authenticatedUser.getUserId());
+	}
+
+	private void validateAccessAuthority(Review review, AuthenticatedUser authenticatedUser) {
+		boolean isAuthor = review.getAuthorId().equals(authenticatedUser.getUserId());
+		boolean isMaster = "MASTER".equals(authenticatedUser.getRole());
+
+		if (!(isAuthor || isMaster)) {
+			throw new ReviewException(ResponseCode.FORBIDDEN_REVIEW_ACCESS);
+		}
+	}
+}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/presentation/controller/ReviewController.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/presentation/controller/ReviewController.java
@@ -31,7 +31,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/reviews")
 public class ReviewController {
 
-	private final ReviewService reviewService;
+	private final ReviewService reviewServices;
 	private final ReviewLikeService reviewLikeService;
 
 	@PostMapping
@@ -40,14 +40,14 @@ public class ReviewController {
 		AuthenticatedUser authenticatedUser) {
 
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(ApiResponseData.success(reviewService.registerReview(reviewRegisterReqDto, authenticatedUser)));
+			.body(ApiResponseData.success(reviewServices.registerReview(reviewRegisterReqDto, authenticatedUser)));
 
 	}
 
 	@GetMapping("/{id}")
 	public ResponseEntity<ApiResponseData<ReviewDetailResDto>> getReviewDetail(@PathVariable("id") UUID id) {
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(ApiResponseData.success(reviewService.getReviewDetail(id)));
+			.body(ApiResponseData.success(reviewServices.getReviewDetail(id)));
 	}
 
 	@GetMapping("/search")
@@ -60,7 +60,7 @@ public class ReviewController {
 		@RequestParam(defaultValue = "desc") String order) {
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(
-				ApiResponseData.success(reviewService.searchReview(q, category, page, size, sort, order)));
+				ApiResponseData.success(reviewServices.searchReview(q, category, page, size, sort, order)));
 	}
 
 	@PatchMapping("/{id}")
@@ -68,13 +68,13 @@ public class ReviewController {
 		@Valid @RequestBody ReviewUpdateReqDto reviewUpdateReqDto,
 		AuthenticatedUser authenticatedUser) {
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(ApiResponseData.success(reviewService.updateReview(id, reviewUpdateReqDto, authenticatedUser)));
+			.body(ApiResponseData.success(reviewServices.updateReview(id, reviewUpdateReqDto, authenticatedUser)));
 	}
 
 	@DeleteMapping("/{id}")
 	public ResponseEntity<ApiResponseData<Void>> deleteReview(@PathVariable("id") UUID id,
 		AuthenticatedUser authenticatedUser) {
-		reviewService.deleteReview(id, authenticatedUser);
+		reviewServices.deleteReview(id, authenticatedUser);
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(ApiResponseData.success());
 	}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/presentation/controller/ReviewController.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/presentation/controller/ReviewController.java
@@ -20,6 +20,7 @@ import com.taken_seat.review_service.application.dto.request.ReviewRegisterReqDt
 import com.taken_seat.review_service.application.dto.request.ReviewUpdateReqDto;
 import com.taken_seat.review_service.application.dto.response.PageReviewResponseDto;
 import com.taken_seat.review_service.application.dto.response.ReviewDetailResDto;
+import com.taken_seat.review_service.application.service.ReviewLikeService;
 import com.taken_seat.review_service.application.service.ReviewService;
 
 import jakarta.validation.Valid;
@@ -31,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class ReviewController {
 
 	private final ReviewService reviewService;
+	private final ReviewLikeService reviewLikeService;
 
 	@PostMapping
 	public ResponseEntity<ApiResponseData<ReviewDetailResDto>> registerReview(
@@ -76,5 +78,15 @@ public class ReviewController {
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(ApiResponseData.success());
 	}
+
+	@PostMapping("/{id}/like")
+	public ResponseEntity<ApiResponseData<Void>> toggleReviewLike(@PathVariable("id") UUID id,
+		AuthenticatedUser authenticatedUser) {
+		reviewLikeService.toggleReviewLike(id, authenticatedUser);
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(ApiResponseData.success());
+	}
+
 }
 

--- a/com.taken_seat.review-service/src/test/java/com/taken_seat/review_service/unit/ReviewLikeServiceTest.java
+++ b/com.taken_seat.review-service/src/test/java/com/taken_seat/review_service/unit/ReviewLikeServiceTest.java
@@ -1,0 +1,78 @@
+package com.taken_seat.review_service.unit;
+
+import static org.mockito.Mockito.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import com.taken_seat.common_service.dto.AuthenticatedUser;
+import com.taken_seat.review_service.infrastructure.service.ReviewLikeServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+public class ReviewLikeServiceTest {
+
+	@InjectMocks
+	private ReviewLikeServiceImpl reviewLikeService;
+
+	@Mock
+	private RedisTemplate<String, Integer> likeCountRedisTemplate;
+
+	@Mock
+	private HashOperations<String, Object, Object> hashOperations;
+
+	private UUID reviewId;
+	private UUID userId;
+	private AuthenticatedUser user;
+
+	@BeforeEach
+	void setUp() {
+		reviewId = UUID.randomUUID();
+		userId = UUID.randomUUID();
+		user = new AuthenticatedUser(userId, "user@example.com", "USER");
+
+		when(likeCountRedisTemplate.opsForHash()).thenReturn(hashOperations);
+	}
+
+	@Test
+	@DisplayName("\"리뷰에 좋아요를 처음 누르면 좋아요가 등록되고 count가 1 증가한다- SUCCESS")
+	void testToggleReviewLike_increaseLikeCount() {
+		// given
+		String key = "review:like:" + reviewId;
+		String userField = "user:" + userId;
+
+		when(hashOperations.hasKey(key, userField)).thenReturn(false); // 좋아요를 누르지 않은 상태
+
+		// when
+		reviewLikeService.toggleReviewLike(reviewId, user);
+
+		// then
+		verify(hashOperations).put(key, userField, true); // 좋아요 등록
+		verify(hashOperations).increment(key, "count", 1); // count 증가
+	}
+
+	@Test
+	@DisplayName("이미 좋아요를 누른 상태에서 다시 누르면 좋아요가 삭제되고 count가 1 감소한다  - SUCCESS")
+	void testToggleReviewLike_decreaseLikeCount() {
+		// given
+		String key = "review:like:" + reviewId;
+		String userField = "user:" + userId;
+
+		when(hashOperations.hasKey(key, userField)).thenReturn(true); // 이미 좋아요를 누른 상태
+
+		// when
+		reviewLikeService.toggleReviewLike(reviewId, user);
+
+		// then
+		verify(hashOperations).delete(key, userField); // 좋아요 삭제
+		verify(hashOperations).increment(key, "count", -1); // count 감소
+	}
+}

--- a/com.taken_seat.review-service/src/test/java/com/taken_seat/review_service/unit/ReviewServicesTest.java
+++ b/com.taken_seat.review-service/src/test/java/com/taken_seat/review_service/unit/ReviewServicesTest.java
@@ -27,15 +27,15 @@ import com.taken_seat.review_service.application.dto.request.ReviewRegisterReqDt
 import com.taken_seat.review_service.application.dto.request.ReviewUpdateReqDto;
 import com.taken_seat.review_service.application.dto.response.PageReviewResponseDto;
 import com.taken_seat.review_service.application.dto.response.ReviewDetailResDto;
-import com.taken_seat.review_service.application.service.ReviewService;
 import com.taken_seat.review_service.domain.model.Review;
 import com.taken_seat.review_service.domain.repository.ReviewQuerydslRepository;
 import com.taken_seat.review_service.domain.repository.ReviewRepository;
 import com.taken_seat.review_service.infrastructure.client.dto.BookingStatusDto;
 import com.taken_seat.review_service.infrastructure.client.dto.PerformanceEndTimeDto;
+import com.taken_seat.review_service.infrastructure.service.ReviewServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
-public class ReviewServiceTest {
+public class ReviewServicesTest {
 
 	@Mock
 	private ReviewRepository reviewRepository;
@@ -47,7 +47,7 @@ public class ReviewServiceTest {
 	private ReviewClient reviewClient;
 
 	@InjectMocks
-	private ReviewService reviewService;
+	private ReviewServiceImpl reviewServices;
 
 	private UUID testPerformanceId;
 
@@ -104,7 +104,7 @@ public class ReviewServiceTest {
 		when(reviewRepository.save(any(Review.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
 		// When
-		ReviewDetailResDto result = reviewService.registerReview(requestDto, authenticatedUser);
+		ReviewDetailResDto result = reviewServices.registerReview(requestDto, authenticatedUser);
 
 		// Then
 		assertNotNull(result);
@@ -125,7 +125,7 @@ public class ReviewServiceTest {
 
 		// When & Then
 		ReviewException ex = assertThrows(ReviewException.class, () -> {
-			reviewService.registerReview(requestDto, authenticatedUser);
+			reviewServices.registerReview(requestDto, authenticatedUser);
 		});
 
 		assertEquals(ResponseCode.REVIEW_ALREADY_WRITTEN.getMessage(), ex.getMessage());
@@ -144,7 +144,7 @@ public class ReviewServiceTest {
 
 		// When & Then
 		ReviewException ex = assertThrows(ReviewException.class, () -> {
-			reviewService.registerReview(requestDto, authenticatedUser);
+			reviewServices.registerReview(requestDto, authenticatedUser);
 		});
 
 		assertEquals(ResponseCode.BOOKING_NOT_COMPLETED.getMessage(), ex.getMessage());
@@ -165,7 +165,7 @@ public class ReviewServiceTest {
 
 		// When & Then
 		ReviewException ex = assertThrows(ReviewException.class, () -> {
-			reviewService.registerReview(requestDto, authenticatedUser);
+			reviewServices.registerReview(requestDto, authenticatedUser);
 		});
 
 		assertEquals(ResponseCode.EARLY_REVIEW.getMessage(), ex.getMessage());
@@ -178,7 +178,7 @@ public class ReviewServiceTest {
 		when(reviewRepository.findByIdAndDeletedAtIsNull(testReviewId)).thenReturn(Optional.of(testReview));
 
 		// When
-		ReviewDetailResDto result = reviewService.getReviewDetail(testReviewId);
+		ReviewDetailResDto result = reviewServices.getReviewDetail(testReviewId);
 
 		// Then
 		assertNotNull(result);
@@ -196,7 +196,7 @@ public class ReviewServiceTest {
 
 		// When & Then
 		ReviewException ex = assertThrows(ReviewException.class, () -> {
-			reviewService.getReviewDetail(TestRegisterReviewId);
+			reviewServices.getReviewDetail(TestRegisterReviewId);
 		});
 
 		assertEquals(ResponseCode.REVIEW_NOT_FOUND.getMessage(), ex.getMessage());
@@ -220,7 +220,7 @@ public class ReviewServiceTest {
 		when(reviewQuerydslRepository.search(query, category, page, size, sort, order)).thenReturn(mockPage);
 
 		// When
-		PageReviewResponseDto result = reviewService.searchReview(query, category, page, size, sort, order);
+		PageReviewResponseDto result = reviewServices.searchReview(query, category, page, size, sort, order);
 
 		// Then
 		assertNotNull(result);
@@ -241,7 +241,7 @@ public class ReviewServiceTest {
 			.thenReturn(Page.empty());
 
 		// When
-		PageReviewResponseDto result = reviewService.searchReview("emptyTitle", "title", 0, 10, "createdAt", "desc");
+		PageReviewResponseDto result = reviewServices.searchReview("emptyTitle", "title", 0, 10, "createdAt", "desc");
 
 		// Then
 		assertNotNull(result);
@@ -259,7 +259,7 @@ public class ReviewServiceTest {
 		when(reviewRepository.findByIdAndDeletedAtIsNull(testReviewId)).thenReturn(Optional.of(testReview));
 
 		// When
-		ReviewDetailResDto result = reviewService.updateReview(testReviewId, reqDto, authenticatedUser);
+		ReviewDetailResDto result = reviewServices.updateReview(testReviewId, reqDto, authenticatedUser);
 
 		// Then
 		assertNotNull(result);
@@ -279,7 +279,7 @@ public class ReviewServiceTest {
 
 		// When & Then
 		ReviewException exception = assertThrows(ReviewException.class, () -> {
-			reviewService.updateReview(notExistId, reqDto, authenticatedUser);
+			reviewServices.updateReview(notExistId, reqDto, authenticatedUser);
 		});
 
 		assertEquals("해당 리뷰가 존재하지않습니다.", exception.getMessage());
@@ -297,7 +297,7 @@ public class ReviewServiceTest {
 
 		// When & Then
 		ReviewException exception = assertThrows(ReviewException.class, () -> {
-			reviewService.updateReview(testReviewId, reqDto, anotherUser);
+			reviewServices.updateReview(testReviewId, reqDto, anotherUser);
 		});
 
 		assertEquals("해당 리뷰에 접근할 권한이 없습니다.", exception.getMessage()); // FORBIDDEN_REVIEW_ACCESS 메시지
@@ -310,7 +310,7 @@ public class ReviewServiceTest {
 		when(reviewRepository.findByIdAndDeletedAtIsNull(testReviewId)).thenReturn(Optional.of(testReview));
 
 		// When
-		assertDoesNotThrow(() -> reviewService.deleteReview(testReviewId, authenticatedUser));
+		assertDoesNotThrow(() -> reviewServices.deleteReview(testReviewId, authenticatedUser));
 
 		// Then
 		assertNotNull(testReview.getDeletedAt());
@@ -326,7 +326,7 @@ public class ReviewServiceTest {
 		AuthenticatedUser anotherUser = new AuthenticatedUser(notAuthorId, "other@gmail.com", "other@gmail.com");
 		// When & Then
 		ReviewException exception = assertThrows(ReviewException.class, () ->
-			reviewService.deleteReview(UUID.randomUUID(), anotherUser)
+			reviewServices.deleteReview(UUID.randomUUID(), anotherUser)
 		);
 
 		assertEquals("해당 리뷰가 존재하지않습니다.", exception.getMessage());
@@ -343,7 +343,7 @@ public class ReviewServiceTest {
 
 		// When & Then
 		ReviewException exception = assertThrows(ReviewException.class, () -> {
-			reviewService.deleteReview(testReviewId, anotherUser);
+			reviewServices.deleteReview(testReviewId, anotherUser);
 		});
 
 		assertEquals("해당 리뷰에 접근할 권한이 없습니다.", exception.getMessage()); // FORBIDDEN_REVIEW_ACCESS 메시지


### PR DESCRIPTION
## 개요
리뷰 좋아요 기능을 구현했습니다.

처음에는 비관락을 사용해 구현했는데 디비 접근이 너무 많아 Write-Behind ( Write-Back) Cache 전략을 사용했습니다.

## 작업 내용
### 변경 사항
- `POST /api/v1/reviews/{id}/like` 요청을 처리
- 한 유저는 한 리뷰에 대해 하나의 좋아요만 등록할 수 있도록 처리
- 이미 좋아요가 되어 있으면 취소, 아니면 등록하는 방식의 토글 기능 구현
- 삭제된 좋아요가 있을 경우 복구 처리
 - Redis Hash를 이용해 사용자별 리뷰 좋아요 상태 및 총 수 저장
  - 좋아요 토글 시 count 값 증감 처리 (increment)
  - 매 5분마다 Redis에 저장된 좋아요 수를 DB로 반영하는 스케줄러 추가
  - 저장 완료된 리뷰 키는 Redis에서 삭제 처리
  - Redis key 및 field prefix 상수로 분리하여 관리
### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #127 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
