### PR TITLE
#40 <Performance> 좌석 배치도 API 구현

### DIFF
--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/request/BookingSeatClientRequestDto.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/request/BookingSeatClientRequestDto.java
@@ -1,0 +1,15 @@
+package com.taken_seat.common_service.dto.request;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BookingSeatClientRequestDto {
+
+	private UUID performanceId;
+	private UUID performanceScheduleId;
+	private UUID seatId;
+}

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/response/BookingSeatClientResponseDto.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/response/BookingSeatClientResponseDto.java
@@ -1,0 +1,8 @@
+package com.taken_seat.common_service.dto.response;
+
+public record BookingSeatClientResponseDto(
+	Integer price,
+	boolean reserved,
+	String reason
+) {
+}

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/exception/enums/ResponseCode.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/exception/enums/ResponseCode.java
@@ -67,13 +67,14 @@ public enum ResponseCode {
 		"인터럽트가 발생했습니다."),
 
 	// Performance
-	PERFORMANCE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당 공연은 존재하지 않습니다"),
+	PERFORMANCE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당 공연은 존재하지 않습니다."),
 	PERFORMANCE_VALIDATION_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "동일 공연장에 겹치는 회차가 존재합니다."),
 	PERFORMANCE_HALL_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당 공연장은 존재하지 않습니다"),
 	PERFORMANCE_HALL_ALREADY_EXISTS(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "이미 존재하는 공연장입니다."),
 	PERFORMANCE_HALL_DUPLICATE_SEAT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "중복된 좌석이 존재합니다."),
-
-	;
+	SEAT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당 좌석은 존재하지 않습니다."),
+	SEAT_STATUS_CHANGE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, HttpStatus.NOT_FOUND.value(), "비활성 좌석은 상태를 변경할 수 없습니다."),
+	SEAT_PRICE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "좌석 가격 정보를 찾을 수 없습니다.");
 
 	private final HttpStatus status;
 	private final Integer code;

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/exception/enums/ResponseCode.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/exception/enums/ResponseCode.java
@@ -69,6 +69,7 @@ public enum ResponseCode {
 	// Performance
 	PERFORMANCE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당 공연은 존재하지 않습니다."),
 	PERFORMANCE_VALIDATION_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "동일 공연장에 겹치는 회차가 존재합니다."),
+	PERFORMANCE_SCHEDULE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당 공연 회차가 존재하지 않습니다"),
 	PERFORMANCE_HALL_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당 공연장은 존재하지 않습니다"),
 	PERFORMANCE_HALL_ALREADY_EXISTS(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "이미 존재하는 공연장입니다."),
 	PERFORMANCE_HALL_DUPLICATE_SEAT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "중복된 좌석이 존재합니다."),

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
@@ -101,7 +101,7 @@ public class Performance extends BaseTimeEntity {
 		return schedules.stream()
 			.filter(performanceSchedule -> performanceSchedule.getId().equals(performanceScheduleId))
 			.findFirst()
-			.orElseThrow(() -> new IllegalArgumentException("공연 회차가 존재하지 않습니다"));
+			.orElseThrow(() -> new PerformanceException(ResponseCode.PERFORMANCE_SCHEDULE_NOT_FOUND_EXCEPTION));
 	}
 
 	public Integer findPriceByScheduleAndSeatType(UUID performanceScheduleId, SeatType seatType) {

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
@@ -6,10 +6,13 @@ import java.util.List;
 import java.util.UUID;
 
 import com.taken_seat.common_service.entity.BaseTimeEntity;
+import com.taken_seat.common_service.exception.customException.PerformanceException;
+import com.taken_seat.common_service.exception.enums.ResponseCode;
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.request.UpdateRequestDto;
 import com.taken_seat.performance_service.performance.domain.helper.PerformanceCreateHelper;
 import com.taken_seat.performance_service.performance.domain.helper.PerformanceUpdateHelper;
+import com.taken_seat.performance_service.performancehall.domain.model.SeatType;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -99,5 +102,15 @@ public class Performance extends BaseTimeEntity {
 			.filter(performanceSchedule -> performanceSchedule.getId().equals(performanceScheduleId))
 			.findFirst()
 			.orElseThrow(() -> new IllegalArgumentException("공연 회차가 존재하지 않습니다"));
+	}
+
+	public Integer findPriceByScheduleAndSeatType(UUID performanceScheduleId, SeatType seatType) {
+		return this.schedules.stream()
+			.filter(performanceSchedule -> performanceSchedule.getId().equals(performanceScheduleId))
+			.flatMap(performanceSchedule -> performanceSchedule.getSeatPrices().stream())
+			.filter(performanceSeatPrice -> performanceSeatPrice.getSeatType().equals(seatType))
+			.map(PerformanceSeatPrice::getPrice)
+			.findFirst()
+			.orElseThrow(() -> new PerformanceException(ResponseCode.SEAT_PRICE_NOT_FOUND_EXCEPTION));
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/application/dto/mapper/HallResponseMapper.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/application/dto/mapper/HallResponseMapper.java
@@ -105,4 +105,10 @@ public class HallResponseMapper {
 			)
 			.build();
 	}
+
+	public static List<SeatDto> toSeatLayout(List<Seat> seats) {
+		return seats.stream()
+			.map(HallResponseMapper::toSeat)
+			.collect(Collectors.toList());
+	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/application/dto/response/SeatLayoutResponseDto.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/application/dto/response/SeatLayoutResponseDto.java
@@ -1,0 +1,17 @@
+package com.taken_seat.performance_service.performancehall.application.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SeatLayoutResponseDto {
+
+	private List<SeatDto> seats;
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/application/service/PerformanceHallService.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/application/service/PerformanceHallService.java
@@ -2,6 +2,7 @@ package com.taken_seat.performance_service.performancehall.application.service;
 
 import static com.taken_seat.performance_service.performancehall.application.dto.mapper.HallResponseMapper.*;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -15,6 +16,7 @@ import com.taken_seat.common_service.dto.response.BookingSeatClientResponseDto;
 import com.taken_seat.common_service.exception.customException.PerformanceException;
 import com.taken_seat.common_service.exception.enums.ResponseCode;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
+import com.taken_seat.performance_service.performance.domain.model.PerformanceSchedule;
 import com.taken_seat.performance_service.performance.domain.repository.PerformanceRepository;
 import com.taken_seat.performance_service.performancehall.application.dto.mapper.HallResponseMapper;
 import com.taken_seat.performance_service.performancehall.application.dto.request.CreateRequestDto;
@@ -23,6 +25,8 @@ import com.taken_seat.performance_service.performancehall.application.dto.reques
 import com.taken_seat.performance_service.performancehall.application.dto.response.CreateResponseDto;
 import com.taken_seat.performance_service.performancehall.application.dto.response.DetailResponseDto;
 import com.taken_seat.performance_service.performancehall.application.dto.response.PageResponseDto;
+import com.taken_seat.performance_service.performancehall.application.dto.response.SeatDto;
+import com.taken_seat.performance_service.performancehall.application.dto.response.SeatLayoutResponseDto;
 import com.taken_seat.performance_service.performancehall.application.dto.response.UpdateResponseDto;
 import com.taken_seat.performance_service.performancehall.domain.model.PerformanceHall;
 import com.taken_seat.performance_service.performancehall.domain.model.Seat;
@@ -147,5 +151,23 @@ public class PerformanceHallService {
 		seat.updateStatus(SeatStatus.AVAILABLE);
 
 		return new BookingSeatClientResponseDto(null, false, "좌석 선점이 취소되었습니다.");
+	}
+
+	@Transactional
+	public SeatLayoutResponseDto getSeatLayout(UUID performanceScheduleId) {
+
+		Performance performance = performanceRepository.findByPerformanceScheduleId(performanceScheduleId)
+			.orElseThrow(() -> new PerformanceException(ResponseCode.PERFORMANCE_SCHEDULE_NOT_FOUND_EXCEPTION));
+
+		PerformanceSchedule schedule = performance.getScheduleById(performanceScheduleId);
+
+		UUID performanceHallId = schedule.getPerformanceHallId();
+
+		PerformanceHall performanceHall = performanceHallRepository.findById(performanceHallId)
+			.orElseThrow(() -> new PerformanceException(ResponseCode.PERFORMANCE_HALL_NOT_FOUND_EXCEPTION));
+
+		List<SeatDto> seatLayout = HallResponseMapper.toSeatLayout(performanceHall.getSeats());
+
+		return new SeatLayoutResponseDto(seatLayout);
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/model/PerformanceHall.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/model/PerformanceHall.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.UUID;
 
 import com.taken_seat.common_service.entity.BaseTimeEntity;
+import com.taken_seat.common_service.exception.customException.PerformanceException;
+import com.taken_seat.common_service.exception.enums.ResponseCode;
 import com.taken_seat.performance_service.performancehall.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performancehall.application.dto.request.UpdateRequestDto;
 import com.taken_seat.performance_service.performancehall.application.dto.request.UpdateSeatDto;
@@ -65,7 +67,7 @@ public class PerformanceHall extends BaseTimeEntity {
 		return this.getSeats().stream()
 			.filter(seat -> seat.getId().equals(seatId))
 			.findFirst()
-			.orElseThrow(() -> new IllegalArgumentException("해당 좌석이 존재하지 않습니다"));
+			.orElseThrow(() -> new PerformanceException(ResponseCode.SEAT_NOT_FOUND_EXCEPTION));
 	}
 
 	public void update(UpdateRequestDto request) {

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/model/Seat.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/model/Seat.java
@@ -3,6 +3,8 @@ package com.taken_seat.performance_service.performancehall.domain.model;
 import java.util.UUID;
 
 import com.taken_seat.common_service.entity.BaseTimeEntity;
+import com.taken_seat.common_service.exception.customException.PerformanceException;
+import com.taken_seat.common_service.exception.enums.ResponseCode;
 import com.taken_seat.performance_service.performancehall.application.dto.request.UpdateSeatDto;
 
 import jakarta.persistence.Column;
@@ -57,5 +59,14 @@ public class Seat extends BaseTimeEntity {
 		this.seatNumber = seatDto.getSeatNumber();
 		this.seatType = seatDto.getSeatType();
 		this.status = seatDto.getStatus();
+	}
+
+	public void updateStatus(SeatStatus newStatus) {
+
+		if (this.status == SeatStatus.DISABLED) {
+			throw new PerformanceException(ResponseCode.SEAT_STATUS_CHANGE_NOT_ALLOWED);
+		}
+
+		this.status = newStatus;
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/repository/PerformanceHallRepository.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/repository/PerformanceHallRepository.java
@@ -20,4 +20,6 @@ public interface PerformanceHallRepository {
 	Page<PerformanceHall> findAll(SearchFilterParam filterParam, Pageable pageable);
 
 	boolean existsByNameAndAddressAndIdNot(String name, String address, UUID id);
+
+	Optional<PerformanceHall> findBySeatId(UUID seatId);
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/infrastructure/repository/PerformanceHallJpaRepository.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/infrastructure/repository/PerformanceHallJpaRepository.java
@@ -5,8 +5,11 @@ import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
 import com.taken_seat.performance_service.performancehall.domain.model.PerformanceHall;
+
+import feign.Param;
 
 public interface PerformanceHallJpaRepository
 	extends JpaRepository<PerformanceHall, UUID>, JpaSpecificationExecutor<PerformanceHall> {
@@ -16,4 +19,11 @@ public interface PerformanceHallJpaRepository
 	Optional<PerformanceHall> findByIdAndDeletedAtIsNull(UUID id);
 
 	boolean existsByNameAndAddressAndIdNot(String name, String address, UUID id);
+
+	@Query("""
+		   SELECT ph FROM PerformanceHall ph
+		   JOIN ph.seats s
+		   WHERE s.id = :seatId
+		""")
+	Optional<PerformanceHall> findBySeatId(@Param("seatId") UUID seatId);
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/infrastructure/repository/PerformanceHallRepositoryImpl.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/infrastructure/repository/PerformanceHallRepositoryImpl.java
@@ -46,4 +46,9 @@ public class PerformanceHallRepositoryImpl implements PerformanceHallRepository 
 	public boolean existsByNameAndAddressAndIdNot(String name, String address, UUID id) {
 		return performanceHallJpaRepository.existsByNameAndAddressAndIdNot(name, address, id);
 	}
+
+	@Override
+	public Optional<PerformanceHall> findBySeatId(UUID seatId) {
+		return performanceHallJpaRepository.findBySeatId(seatId);
+	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/presentation/controller/PerformanceHallController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/presentation/controller/PerformanceHallController.java
@@ -13,12 +13,15 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.taken_seat.common_service.dto.ApiResponseData;
 import com.taken_seat.common_service.dto.AuthenticatedUser;
+import com.taken_seat.common_service.dto.request.BookingSeatClientRequestDto;
+import com.taken_seat.common_service.dto.response.BookingSeatClientResponseDto;
 import com.taken_seat.performance_service.performancehall.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performancehall.application.dto.request.SearchFilterParam;
 import com.taken_seat.performance_service.performancehall.application.dto.request.UpdateRequestDto;
@@ -79,4 +82,21 @@ public class PerformanceHallController {
 		performanceHallService.delete(id, authenticatedUser);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponseData.success());
 	}
+
+	@PutMapping("/seat/status")
+	public ResponseEntity<ApiResponseData<BookingSeatClientResponseDto>> updateSeatStatus(
+		@Valid @RequestBody BookingSeatClientRequestDto request) {
+
+		BookingSeatClientResponseDto response = performanceHallService.updateSeatStatus(request);
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseData.success(response));
+	}
+
+	@PutMapping("/seat/status/cancel")
+	public ResponseEntity<ApiResponseData<BookingSeatClientResponseDto>> cancelSeatStatus(
+		@Valid @RequestBody BookingSeatClientRequestDto request) {
+
+		BookingSeatClientResponseDto response = performanceHallService.cancelSeatStatus(request);
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseData.success(response));
+	}
+
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/presentation/controller/PerformanceHallController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/presentation/controller/PerformanceHallController.java
@@ -28,6 +28,7 @@ import com.taken_seat.performance_service.performancehall.application.dto.reques
 import com.taken_seat.performance_service.performancehall.application.dto.response.CreateResponseDto;
 import com.taken_seat.performance_service.performancehall.application.dto.response.DetailResponseDto;
 import com.taken_seat.performance_service.performancehall.application.dto.response.PageResponseDto;
+import com.taken_seat.performance_service.performancehall.application.dto.response.SeatLayoutResponseDto;
 import com.taken_seat.performance_service.performancehall.application.dto.response.UpdateResponseDto;
 import com.taken_seat.performance_service.performancehall.application.service.PerformanceHallService;
 
@@ -99,4 +100,11 @@ public class PerformanceHallController {
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseData.success(response));
 	}
 
+	@GetMapping("/seats/{performanceScheduleId}")
+	public ResponseEntity<ApiResponseData<SeatLayoutResponseDto>> getSeatLayout(
+		@PathVariable("performanceScheduleId") UUID performanceScheduleId) {
+
+		SeatLayoutResponseDto response = performanceHallService.getSeatLayout(performanceScheduleId);
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseData.success(response));
+	}
 }


### PR DESCRIPTION
## 개요
공연 예매 화면에서 사용될 좌석 배치도 정보를 조회하는 기능 구현했습니다

## 작업 내용
### 변경 사항

#### 1. API 컨트롤러

- `GET /api/v1/performancehalls/seats/{performanceScheduleId}`  
  → 회차 ID를 기반으로 공연장의 전체 좌석 목록 반환
- `SeatLayoutResponseDto`를 응답 포맷으로 사용하여 프론트엔드에서 좌석 배치도 렌더링 가능

#### 2. Service 로직

- `performanceRepository.findByPerformanceScheduleId()`  
  → 회차 ID로 공연을 조회
- `Performance.getScheduleById()`  
  → 해당 회차 추출
- `schedule.getPerformanceHallId()`  
  → 연결된 공연장 ID 조회
- `performanceHallRepository.findById()`  
  → 공연장 조회 후 `getSeats()`를 통해 전체 좌석 정보 추출
- `HallResponseMapper.toSeatLayout()`  
  → 도메인 객체를 DTO로 변환하여 반환

#### 3. DTO 구성

- `SeatLayoutResponseDto`
  - `List<SeatDto> seats` 필드 포함

#### 4. 매퍼 추가

- `HallResponseMapper.toSeatLayout()`  
  → 공연장 내 좌석 리스트를 `SeatDto` 리스트로 매핑

#### 5. 예외 처리

- 회차 ID가 존재하지 않을 경우: `PERFORMANCE_SCHEDULE_NOT_FOUND_EXCEPTION`
- 공연장이 존재하지 않을 경우: `PERFORMANCE_HALL_NOT_FOUND_EXCEPTION`

#### 6. 테스트
![image](https://github.com/user-attachments/assets/6cd90309-dde5-4082-931c-59aa09009584)


### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #40 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
