### PR TITLE
#32 <Performance> 공연 및 공연 회차 상태 변경 API

### DIFF
--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/helper/PerformanceCreateHelper.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/helper/PerformanceCreateHelper.java
@@ -1,5 +1,6 @@
 package com.taken_seat.performance_service.performance.domain.helper;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -57,18 +58,22 @@ public class PerformanceCreateHelper {
 	// PerformanceSchedule 객체 생성
 	private static PerformanceSchedule createPerformanceSchedule(
 		CreatePerformanceScheduleDto createPerformanceScheduleDto, Performance performance) {
+
+		LocalDateTime saleStartAt = createPerformanceScheduleDto.getSaleStartAt();
+		LocalDateTime saleEndAt = createPerformanceScheduleDto.getSaleEndAt();
+
+		if (saleEndAt == null) {
+			saleEndAt = saleStartAt.minusMinutes(1);
+		}
+
 		return PerformanceSchedule.builder()
 			.performance(performance)
 			.performanceHallId(createPerformanceScheduleDto.getPerformanceHallId())
 			.startAt(createPerformanceScheduleDto.getStartAt())
 			.endAt(createPerformanceScheduleDto.getEndAt())
-			.saleStartAt(createPerformanceScheduleDto.getSaleStartAt())
-			.saleEndAt(createPerformanceScheduleDto.getSaleEndAt())
-			.status(PerformanceScheduleStatus.status(
-				createPerformanceScheduleDto.getSaleStartAt(),
-				createPerformanceScheduleDto.getSaleEndAt(),
-				false
-			))
+			.saleStartAt(saleStartAt)
+			.saleEndAt(saleEndAt)
+			.status(PerformanceScheduleStatus.status(saleStartAt, saleEndAt, false))
 			.build();
 	}
 

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
@@ -113,4 +113,8 @@ public class Performance extends BaseTimeEntity {
 			.findFirst()
 			.orElseThrow(() -> new PerformanceException(ResponseCode.SEAT_PRICE_NOT_FOUND_EXCEPTION));
 	}
+
+	public void updateStatus(PerformanceStatus newStatus) {
+		this.status = newStatus;
+	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/PerformanceSchedule.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/PerformanceSchedule.java
@@ -74,4 +74,8 @@ public class PerformanceSchedule extends BaseTimeEntity {
 		this.saleEndAt = dto.getSaleEndAt();
 		this.status = dto.getStatus();
 	}
+
+	public void updateStatus(PerformanceScheduleStatus newStatus) {
+		this.status = newStatus;
+	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/PerformanceScheduleStatus.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/PerformanceScheduleStatus.java
@@ -9,15 +9,16 @@ public enum PerformanceScheduleStatus {
 	CLOSED,
 	SOLDOUT;
 
-	public static PerformanceScheduleStatus status(LocalDateTime startAt, LocalDateTime endAt, boolean isSoldOut) {
+	public static PerformanceScheduleStatus status(LocalDateTime saleStartAt, LocalDateTime saleEndAt,
+		boolean isSoldOut) {
 
 		LocalDateTime now = LocalDateTime.now();
 
-		if (now.isBefore(startAt)) {
+		if (now.isBefore(saleStartAt)) {
 			return PENDING;
 		}
 
-		if (!now.isAfter(endAt)) {
+		if (!now.isAfter(saleEndAt)) {
 			return isSoldOut ? SOLDOUT : ONSALE;
 		}
 

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
@@ -93,4 +93,13 @@ public class PerformanceController {
 		PerformanceEndTimeDto response = performanceService.getPerformanceEndTime(performanceId, performanceScheduleId);
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseData.success(response));
 	}
+
+	@PatchMapping("/{id}/status")
+	public ResponseEntity<ApiResponseData<Void>> updateStatus(
+		@PathVariable("id") UUID id,
+		AuthenticatedUser authenticatedUser) {
+
+		performanceService.updateStatus(id, authenticatedUser);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponseData.success());
+	}
 }


### PR DESCRIPTION
## 개요
공연 및 공연 회차 상태 변경 API 구현했습니다

## 작업 내용
### 변경 사항

#### 1. **API 컨트롤러**
- `PATCH /api/v1/performances/{id}/status`  
→ 공연 및 회차 상태를 실시간 기준으로 갱신하는 API 추가  
→ 공연 ID 기반으로 상태 동기화 수행  

#### 2. **Service**
- `performanceService.updateStatus(...)`  
→ 공연의 전체 상태(`PerformanceStatus`) 계산 및 반영  
→ 각 회차별 상태(`PerformanceScheduleStatus`)를 예매 시간 및 좌석 상태 기준으로 계산  
→ 좌석이 모두 `SOLDOUT` or `DISABLED`일 경우 `SOLDOUT` 상태로 처리  

#### 3. **도메인**
- `Performance.updateStatus(PerformanceStatus newStatus)`  
→ 공연 상태 갱신 메서드 추가  

- `PerformanceSchedule.updateStatus(PerformanceScheduleStatus newStatus)`  
→ 회차 상태 갱신 메서드 추가  

- `PerformanceScheduleStatus.status(...)`  
→ 공연 시간 기반이 아닌 예매 시간 기반 계산으로 리팩터링  
→ `saleStartAt`, `saleEndAt`, `isSoldOut` 기준으로 상태 분기  

#### 4. **Helper**
- `PerformanceCreateHelper.createPerformanceSchedule(...)`  
→ `saleEndAt` 값이 null일 경우, 회차 시작 1분 전으로 기본 설정  
→ 회차 상태 계산 시 `isSoldOut`은 기본 false로 지정하여 최초 상태 처리  

#### 5. **테스트**
- Postman 통해 `/status` PATCH API 정상 동작 확인  
- 회차별 시간 흐름 및 좌석 상태에 따라 `PENDING`, `ONSALE`, `SOLDOUT`, `CLOSED` 정상 계산됨  
- 좌석 상태 변경 후 상태 갱신도 수동 호출로 테스트 완료  
![image](https://github.com/user-attachments/assets/e5eaf88e-22ec-48ba-bb1a-ba230e3aa8fc)

### 변경 이유

### 추가 설명

- 좌석 상태 변경 시 자동으로 상태 반영되도록 `도메인 이벤트` 도입 예정  
- `PerformanceScheduleStatus` → `PerformanceReservationStatus` 이름 변경 고려 중 (역할 명확화)

## 리뷰 요구사항

#### 연관된 이슈
closed #32 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
