### PR TITLE
#207 <Payment> 결제 이벤트 진행중에 히스토리 업데이트 메서드 수정 및 추가

### DIFF
--- a/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/service/PaymentServiceImpl.java
+++ b/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/service/PaymentServiceImpl.java
@@ -162,7 +162,7 @@ public class PaymentServiceImpl implements PaymentService {
 
 		payment.update(paymentUpdateReqDto.getPrice(), paymentUpdateReqDto.getPaymentStatus(),
 			authenticatedUser);
-		paymentHistory.update(payment);
+		paymentHistory.updateHistory(payment);
 		return PaymentDetailResDto.toResponse(payment);
 	}
 

--- a/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/service/UserBenefitEventHandlerServiceImpl.java
+++ b/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/application/service/UserBenefitEventHandlerServiceImpl.java
@@ -4,12 +4,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.taken_seat.common_service.exception.customException.PaymentException;
+import com.taken_seat.common_service.exception.customException.PaymentHistoryException;
 import com.taken_seat.common_service.exception.enums.ResponseCode;
 import com.taken_seat.common_service.message.PaymentResultMessage;
 import com.taken_seat.common_service.message.UserBenefitMessage;
 import com.taken_seat.common_service.message.enums.PaymentResultStatus;
 import com.taken_seat.payment_service.application.kafka.producer.PaymentResultProducer;
+import com.taken_seat.payment_service.domain.enums.PaymentStatus;
 import com.taken_seat.payment_service.domain.model.Payment;
+import com.taken_seat.payment_service.domain.model.PaymentHistory;
+import com.taken_seat.payment_service.domain.repository.PaymentHistoryRepository;
 import com.taken_seat.payment_service.domain.repository.PaymentRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -20,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class UserBenefitEventHandlerServiceImpl implements UserBenefitEventHandlerService {
 
 	private final PaymentRepository paymentRepository;
+	private final PaymentHistoryRepository paymentHistoryRepository;
 	private final PaymentResultProducer paymentResultProducer;
 
 	@Override
@@ -28,9 +33,15 @@ public class UserBenefitEventHandlerServiceImpl implements UserBenefitEventHandl
 		Payment payment = paymentRepository.findByIdAndDeletedAtIsNull(message.getPaymentId())
 			.orElseThrow(() -> new PaymentException(ResponseCode.PAYMENT_NOT_FOUND_EXCEPTION));
 
+		PaymentHistory paymentHistory = paymentHistoryRepository.findByPayment(payment)
+			.orElseThrow(() -> new PaymentHistoryException(ResponseCode.PAYMENT_HISTORY_NOT_FOUND_EXCEPTION));
+
 		int price = payment.getPrice();
 
 		if (!message.getStatus().equals(UserBenefitMessage.UserBenefitStatus.SUCCESS)) {
+
+			payment.updateStatus(PaymentStatus.FAILED);
+			paymentHistory.updateHistory(payment);
 
 			PaymentResultMessage paymentResultMessage = PaymentResultMessage.builder()
 				.bookingId(payment.getBookingId())
@@ -46,6 +57,9 @@ public class UserBenefitEventHandlerServiceImpl implements UserBenefitEventHandl
 			price = (int)(price - discountAmount); // 할인된 가격 계산
 
 			if (!validPrice(price)) {
+
+				payment.updateStatus(PaymentStatus.FAILED);
+				paymentHistory.updateHistory(payment);
 				throw new PaymentException(ResponseCode.INVALID_COUPON);
 			}
 		}
@@ -54,12 +68,17 @@ public class UserBenefitEventHandlerServiceImpl implements UserBenefitEventHandl
 			price -= message.getMileage();
 
 			if (!validPrice(price)) {
+				payment.updateStatus(PaymentStatus.FAILED);
+				paymentHistory.updateHistory(payment);
 				throw new PaymentException(ResponseCode.INVALID_MILEAGE);
 			}
 		}
 
 		payment.updatePrice(price);
 		payment.markAsCompleted(payment.getUserId());
+
+		paymentHistory.markAsCompleted(payment.getUserId());
+		paymentHistory.updateHistory(payment);
 
 		PaymentResultMessage paymentResultMessage = PaymentResultMessage.builder()
 			.bookingId(payment.getBookingId())

--- a/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/domain/model/Payment.java
+++ b/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/domain/model/Payment.java
@@ -88,24 +88,31 @@ public class Payment extends BaseTimeEntity {
 		this.preUpdate(authenticatedUser.getUserId());
 	}
 
-	@Override
-	public void delete(UUID deleteBy) {
-		super.delete(deleteBy);
-		this.paymentStatus = PaymentStatus.DELETED;
-	}
-
 	public void markAsCompleted(UUID userId) {
 		this.paymentStatus = PaymentStatus.COMPLETED;
 		this.approvedAt = LocalDateTime.now();
 		this.preUpdate(userId);
 	}
 
-	public void updatePrice(int price) {
+	public void updateStatus(PaymentStatus paymentStatus) {
+		this.paymentStatus = paymentStatus;
+	}
 
+	public void updatePrice(int price) {
+		validatePrice(price);
+		this.price = price;
+	}
+
+	@Override
+	public void delete(UUID deleteBy) {
+		super.delete(deleteBy);
+		this.paymentStatus = PaymentStatus.DELETED;
+	}
+
+	private void validatePrice(int price) {
 		if (price < 0) {
 			throw new PaymentException(ResponseCode.ILLEGAL_ARGUMENT, "결제 금액은 0보다 작은 값으로 설정할 수 없습니다. 올바른 값을 입력해 주세요.");
 		}
-
-		this.price = price;
 	}
+
 }

--- a/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/domain/model/PaymentHistory.java
+++ b/com.taken_seat.payment-service/src/main/java/com/taken_seat/payment_service/domain/model/PaymentHistory.java
@@ -63,10 +63,19 @@ public class PaymentHistory extends BaseTimeEntity {
 		return paymentHistory;
 	}
 
-	public void update(Payment payment) {
+	public void updateHistory(Payment payment) {
 		this.price = payment.getPrice();
 		this.paymentStatus = payment.getPaymentStatus();
+		this.approvedAt = payment.getApprovedAt();
+		this.refundAmount = payment.getRefundAmount();
+		this.refundRequestedAt = payment.getRefundRequestedAt();
 		this.preUpdate(payment.getUpdatedBy());
+	}
+
+	public void markAsCompleted(UUID userId) {
+		this.paymentStatus = PaymentStatus.COMPLETED;
+		this.approvedAt = LocalDateTime.now();
+		this.preUpdate(userId);
 	}
 
 	@Override
@@ -75,9 +84,4 @@ public class PaymentHistory extends BaseTimeEntity {
 		this.paymentStatus = PaymentStatus.DELETED;
 	}
 
-	public void markAsCompleted(UUID userId) {
-		this.paymentStatus = PaymentStatus.COMPLETED;
-		this.approvedAt = LocalDateTime.now();
-		this.preUpdate(userId);
-	}
 }


### PR DESCRIPTION
## 개요
결제 내용이 갱신될 떄마다 히스토리도 동기되어야하는데 그러지않아 업데이트로직을 추가했습니다.

## 작업 내용
### 변경 사항
- 각 상황에서 payment가 업데이트될 때 마다 히스토리도 동일하게 갱신되게했습니다.

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
