### PR TITLE
#161 <Booking> 예매 도메인에서 쿠폰, 마일리지 차감

### DIFF
--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/dto/response/BookingReadResponse.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/dto/response/BookingReadResponse.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class BookingReadResponse {
 	private UUID id;
+	private UUID performanceId;
 	private UUID performanceScheduleId;
 	private UUID seatId;
 	private UUID paymentId;
@@ -27,6 +28,7 @@ public class BookingReadResponse {
 	public static BookingReadResponse toDto(Booking booking) {
 		return BookingReadResponse.builder()
 			.id(booking.getId())
+			.performanceId(booking.getPerformanceId())
 			.performanceScheduleId(booking.getPerformanceScheduleId())
 			.seatId(booking.getSeatId())
 			.paymentId(booking.getPaymentId())

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingProducer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingProducer.java
@@ -1,9 +1,15 @@
 package com.taken_seat.booking_service.booking.application.service;
 
 import com.taken_seat.booking_service.common.message.TicketRequestMessage;
+import com.taken_seat.common_service.message.PaymentMessage;
+import com.taken_seat.common_service.message.UserBenefitMessage;
 
 public interface BookingProducer {
-	void sendPaymentRequestEvent(PaymentRequestMessage message);
+	void sendPaymentRequestEvent(PaymentMessage message);
 
 	void sendPaymentCompleteEvent(TicketRequestMessage message);
+
+	void sendBenefitUsageRequest(UserBenefitMessage message);
+
+	void sendBenefitRefundRequest(UserBenefitMessage message);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingService.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingService.java
@@ -12,6 +12,8 @@ import com.taken_seat.booking_service.booking.application.dto.response.BookingCr
 import com.taken_seat.booking_service.booking.application.dto.response.BookingPageResponse;
 import com.taken_seat.booking_service.booking.application.dto.response.BookingReadResponse;
 import com.taken_seat.common_service.dto.AuthenticatedUser;
+import com.taken_seat.common_service.message.PaymentMessage;
+import com.taken_seat.common_service.message.UserBenefitMessage;
 
 public interface BookingService {
 	BookingCreateResponse createBooking(AuthenticatedUser authenticatedUser, BookingCreateRequest request);
@@ -30,5 +32,7 @@ public interface BookingService {
 
 	void createPayment(AuthenticatedUser authenticatedUser, UUID id, BookingPayRequest request);
 
-	void updateBooking(PaymentResultMessage message);
+	void updateBooking(PaymentMessage message);
+
+	void createPayment(UserBenefitMessage message);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/domain/Booking.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/domain/Booking.java
@@ -56,6 +56,8 @@ public class Booking extends BaseEntity {
 
 	private int price;
 
+	private int discountedPrice;
+
 	@Builder.Default
 	@Enumerated(EnumType.STRING)
 	private BookingStatus bookingStatus = BookingStatus.PENDING;
@@ -66,5 +68,9 @@ public class Booking extends BaseEntity {
 
 	public void cancel() {
 		this.canceledAt = LocalDateTime.now();
+	}
+
+	public void discount(int price) {
+		this.discountedPrice = price;
 	}
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaConsumer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaConsumer.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Component;
 
 import com.taken_seat.booking_service.booking.application.service.BookingService;
 import com.taken_seat.booking_service.booking.presentation.BookingConsumer;
+import com.taken_seat.common_service.message.PaymentMessage;
+import com.taken_seat.common_service.message.UserBenefitMessage;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,8 +18,15 @@ public class BookingKafkaConsumer implements BookingConsumer {
 
 	@Override
 	@KafkaListener(topics = "payment.result", groupId = "booking-service")
-	public void updateBooking(PaymentResultMessage message) {
+	public void updateBooking(PaymentMessage message) {
 
 		bookingService.updateBooking(message);
+	}
+
+	@Override
+	@KafkaListener(topics = "benefit.usage.response", groupId = "booking-service")
+	public void createPayment(UserBenefitMessage message) {
+
+		bookingService.createPayment(message);
 	}
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaProducer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaProducer.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Component;
 
 import com.taken_seat.booking_service.booking.application.service.BookingProducer;
 import com.taken_seat.booking_service.common.message.TicketRequestMessage;
+import com.taken_seat.common_service.message.PaymentMessage;
+import com.taken_seat.common_service.message.UserBenefitMessage;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,7 +17,7 @@ public class BookingKafkaProducer implements BookingProducer {
 	private final KafkaTemplate<String, Object> kafkaTemplate;
 
 	@Override
-	public void sendPaymentRequestEvent(PaymentRequestMessage message) {
+	public void sendPaymentRequestEvent(PaymentMessage message) {
 
 		kafkaTemplate.send("payment.request", message);
 	}
@@ -24,5 +26,17 @@ public class BookingKafkaProducer implements BookingProducer {
 	public void sendPaymentCompleteEvent(TicketRequestMessage message) {
 
 		kafkaTemplate.send("ticket.request", message);
+	}
+
+	@Override
+	public void sendBenefitUsageRequest(UserBenefitMessage message) {
+
+		kafkaTemplate.send("benefit.usage.request", message);
+	}
+
+	@Override
+	public void sendBenefitRefundRequest(UserBenefitMessage message) {
+
+		kafkaTemplate.send("benefit.refund.request", message);
 	}
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/presentation/BookingConsumer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/presentation/BookingConsumer.java
@@ -1,5 +1,10 @@
 package com.taken_seat.booking_service.booking.presentation;
 
+import com.taken_seat.common_service.message.PaymentMessage;
+import com.taken_seat.common_service.message.UserBenefitMessage;
+
 public interface BookingConsumer {
-	void updateBooking(PaymentResultMessage message);
+	void updateBooking(PaymentMessage message);
+
+	void createPayment(UserBenefitMessage message);
 }

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/message/UserBenefitMessage.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/message/UserBenefitMessage.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class UserBenefitMessage {
 
-	private UUID paymentId;
+	private UUID bookingId;
 
 	private UUID userId;
 


### PR DESCRIPTION
## 개요
결제 도메인에 있던 쿠폰, 마일리지 차감 기능을 예매 도메인으로 옮겼습니다.

## 작업 내용
1. Booking 엔티티에 할인가 정보를 추가했습니다.
2. Booking 조회 Dto 에 performanceId 추가했습니다.
3. 결제 시도시 쿠폰, 마일리지를 사용하지 않으면 바로 결제 요청을 보내고 사용한다면 Auth 서비스에 요청 후 응답이 오면 할인가로 결제 요청을 보내도록 했습니다.
### 변경 사항

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
#161 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
