### PR TITLE
#232 <Queue> kafka 적용

### DIFF
--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/message/BookingRequestMessage.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/message/BookingRequestMessage.java
@@ -1,0 +1,19 @@
+package com.taken_seat.common_service.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@NoArgsConstructor
+public class BookingRequestMessage {
+    private UUID userId;
+    private UUID performanceId;
+    private UUID performanceScheduleId;
+}
+

--- a/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/application/kafka/QueueKafkaProducer.java
+++ b/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/application/kafka/QueueKafkaProducer.java
@@ -1,0 +1,8 @@
+package com.taken_seat.queue_service.application.kafka;
+
+
+import com.taken_seat.common_service.message.BookingRequestMessage;
+
+public interface QueueKafkaProducer {
+    void sendBookingRequestEvent(BookingRequestMessage message);
+}

--- a/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/application/service/QueueService.java
+++ b/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/application/service/QueueService.java
@@ -44,19 +44,20 @@ public class QueueService {
 
         //이 토큰을 프론트에서 지니고 있다가 유저 랭크 조회 시 해당 토큰을 통해 알려주기
         log.info("토큰 발급 및 대기열 진입 성공: " + token);
+        log.info(getRank(token));
         return token;
     }
 
     public String getRank(String token) {
         if (!jwt.validateToken(token))
-            return "대기열에 존재 x";
+            return "유효하지 않은 토큰"; //예외처리 필요
 
         String key = jwt.getPerformanceId(token);
 
         Long queueSize = queueRepository.getQueueSize(key);
         Long userRank = queueRepository.getRank(token, key);
 
-        return "총 대기자 수: " + queueSize + ", 현재 대기 순번: " + userRank;
+        return "총 대기자 수: " + queueSize + ", 현재 대기 순번: " + (userRank + 1);
     }
 
     public void processQueueBatch(int batchSize) {

--- a/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/application/service/QueueService.java
+++ b/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/application/service/QueueService.java
@@ -1,7 +1,9 @@
 package com.taken_seat.queue_service.application.service;
 
+import com.taken_seat.common_service.message.BookingRequestMessage;
 import com.taken_seat.queue_service.application.dto.QueueReqDto;
 import com.taken_seat.queue_service.infrastructure.jwt.JwtImpl;
+import com.taken_seat.queue_service.infrastructure.messaging.QueueKafkaProducerImpl;
 import com.taken_seat.queue_service.infrastructure.repository.QueueRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,7 @@ import java.util.UUID;
 public class QueueService {
     private final JwtImpl jwt;
     private final QueueRepository queueRepository;
+    private final QueueKafkaProducerImpl kafkaProducer;
 
     public String enterQueue(QueueReqDto reqDto) {
         String token = jwt.createAccessToken(UUID.randomUUID(), reqDto.getPerformanceId(), reqDto.getPerformanceScheduleId());
@@ -63,7 +66,8 @@ public class QueueService {
             List<String> users = queueRepository.getTopUsers(performance, batchSize);
             for (String token : users) {
                 //카프카 이벤트 전송
-                log.info("카프카 이벤트 전송 성공: " + token);
+                sendEvent(token);
+                log.info("카프카 이벤트 전송 성공. 공연 UUID: " + performance);
             }
 
             queueRepository.removeTopUsers(performance, batchSize);
@@ -77,5 +81,13 @@ public class QueueService {
                 log.info("대기자 없음. 공연 set에서 삭제: " + performance);
             }
         }
+    }
+
+    private void sendEvent(String token) {
+        UUID userId = UUID.fromString(jwt.getUserId(token));
+        UUID performanceId = UUID.fromString(jwt.getPerformanceId(token));
+        UUID performanceScheduleId = UUID.fromString(jwt.getPerformanceScheduleId(token));
+
+        kafkaProducer.sendBookingRequestEvent(new BookingRequestMessage(userId, performanceId, performanceScheduleId));
     }
 }

--- a/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/infrastructure/messaging/QueueKafkaProducerImpl.java
+++ b/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/infrastructure/messaging/QueueKafkaProducerImpl.java
@@ -13,11 +13,11 @@ public class QueueKafkaProducerImpl implements QueueKafkaProducer {
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Value("${kafka.topic.queue-request}")
-    private String topic;
+    private String TOPIC;
 
     @Override
     public void sendBookingRequestEvent(BookingRequestMessage message) {
         //공연 Id를 키로 사용하여 동일 파티션 내에서 유저 순서 보장
-        kafkaTemplate.send(topic, message.getPerformanceId().toString(), message);
+        kafkaTemplate.send(TOPIC, message.getPerformanceId().toString(), message);
     }
 }

--- a/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/infrastructure/messaging/QueueKafkaProducerImpl.java
+++ b/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/infrastructure/messaging/QueueKafkaProducerImpl.java
@@ -1,0 +1,23 @@
+package com.taken_seat.queue_service.infrastructure.messaging;
+
+import com.taken_seat.common_service.message.BookingRequestMessage;
+import com.taken_seat.queue_service.application.kafka.QueueKafkaProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QueueKafkaProducerImpl implements QueueKafkaProducer {
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${kafka.topic.queue-request}")
+    private String topic;
+
+    @Override
+    public void sendBookingRequestEvent(BookingRequestMessage message) {
+        //공연 Id를 키로 사용하여 동일 파티션 내에서 유저 순서 보장
+        kafkaTemplate.send(topic, message.getPerformanceId().toString(), message);
+    }
+}


### PR DESCRIPTION
- 예매로 대기자를 보내주는 kafka 메시징 적용

## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 작업 내용
### 변경 사항
- QueueService에 sendEvent 메소드 추가
- QueueKafkaProducer 인터페이스 및 QueueKafkaProducerImpl 구현
- common의 message 패키지에 BookingRequestMessage DTO 추가

- topic 수정
- 대기열 진입 시 대기 순번 log 추가

### 변경 이유
- 기존 queue.request 토픽에 이미 오류가 생긴 상황에서 자꾸 그 토픽으로 메시지를 전송하니까 오류가 생겨서 새로 토픽 생성
-> key 잘 들어가고, UI에서 메시지 전송 잘 되는거 확인했습니다!

### 추가 설명
- 예매로 대기 인원 보낼 때 토큰을 보내는게 아니라 유저, 공연, 공연 회차의 ID를 객체로 보내도록 구현해뒀습니다! 대기 인원 받으실 때 참고하시면 될 것 같습니당

- 새 토픽으로 변경해서 YML 파일 업데이트 해뒀습니다

## 리뷰 요구사항

#### 연관된 이슈
closed #232 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [0] 새로운 기능 추가
- [0] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
