### PR TITLE
feat: #235 <Booking> 쿠폰, 마일리지 기록 저장 및 원복처리 요청

### DIFF
--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingService.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingService.java
@@ -35,4 +35,6 @@ public interface BookingService {
 	void updateBooking(PaymentMessage message);
 
 	void createPayment(UserBenefitMessage message);
+
+	void updateBenefitUsageHistory(UserBenefitMessage message);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/domain/BenefitUsageHistory.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/domain/BenefitUsageHistory.java
@@ -1,0 +1,43 @@
+package com.taken_seat.booking_service.booking.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.taken_seat.booking_service.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "p_benefit_usage_history")
+public class BenefitUsageHistory extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	@Column(nullable = false)
+	private UUID bookingId;
+
+	private UUID couponId;
+	private Integer mileage;
+	private LocalDateTime usedAt;
+	private boolean refunded;
+
+	public void refunded() {
+		this.refunded = true;
+	}
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/domain/repository/BenefitUsageHistoryRepository.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/domain/repository/BenefitUsageHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.taken_seat.booking_service.booking.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.taken_seat.booking_service.booking.domain.BenefitUsageHistory;
+
+public interface BenefitUsageHistoryRepository {
+	BenefitUsageHistory save(BenefitUsageHistory benefitUsageHistory);
+
+	Optional<BenefitUsageHistory> findByBookingIdAndRefundedIsFalse(UUID bookingId);
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaConsumer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaConsumer.java
@@ -29,4 +29,11 @@ public class BookingKafkaConsumer implements BookingConsumer {
 
 		bookingService.createPayment(message);
 	}
+
+	@Override
+	@KafkaListener(topics = "benefit.refund.response", groupId = "booking-service")
+	public void updateBenefitUsageHistory(UserBenefitMessage message) {
+
+		bookingService.updateBenefitUsageHistory(message);
+	}
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/repository/BenefitUsageHistoryJpaRepository.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/repository/BenefitUsageHistoryJpaRepository.java
@@ -1,0 +1,12 @@
+package com.taken_seat.booking_service.booking.infrastructure.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.taken_seat.booking_service.booking.domain.BenefitUsageHistory;
+
+public interface BenefitUsageHistoryJpaRepository extends JpaRepository<BenefitUsageHistory, UUID> {
+	Optional<BenefitUsageHistory> findByBookingIdAndRefundedIsFalse(UUID bookingId);
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/repository/BenefitUsageHistoryRepositoryImpl.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/repository/BenefitUsageHistoryRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.taken_seat.booking_service.booking.infrastructure.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.taken_seat.booking_service.booking.domain.BenefitUsageHistory;
+import com.taken_seat.booking_service.booking.domain.repository.BenefitUsageHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BenefitUsageHistoryRepositoryImpl implements BenefitUsageHistoryRepository {
+
+	private final BenefitUsageHistoryJpaRepository benefitUsageHistoryJpaRepository;
+
+	@Override
+	public BenefitUsageHistory save(BenefitUsageHistory benefitUsageHistory) {
+		return benefitUsageHistoryJpaRepository.save(benefitUsageHistory);
+	}
+
+	@Override
+	public Optional<BenefitUsageHistory> findByBookingIdAndRefundedIsFalse(UUID bookingId) {
+		return benefitUsageHistoryJpaRepository.findByBookingIdAndRefundedIsFalse(bookingId);
+	}
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/presentation/BookingConsumer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/presentation/BookingConsumer.java
@@ -7,4 +7,6 @@ public interface BookingConsumer {
 	void updateBooking(PaymentMessage message);
 
 	void createPayment(UserBenefitMessage message);
+
+	void updateBenefitUsageHistory(UserBenefitMessage message);
 }

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/exception/enums/ResponseCode.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/exception/enums/ResponseCode.java
@@ -74,6 +74,10 @@ public enum ResponseCode {
 
 	// Booking
 	BOOKING_ALREADY_CANCELED_EXCEPTION(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "이미 취소된 예약입니다."),
+	BOOKING_BENEFIT_USAGE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(),
+		"쿠폰, 마일리지 사용 내역이 없습니다."),
+	BOOKING_BENEFIT_USAGE_REFUND_FAILED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,
+		HttpStatus.INTERNAL_SERVER_ERROR.value(), "쿠폰, 마일리지 원복처리가 실패했습니다."),
 	BOOKING_INTERRUPTED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.value(),
 		"인터럽트가 발생했습니다."),
 	BOOKING_NOT_CANCELED_EXCEPTION(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "예약 취소 후 삭제할 수 있습니다."),


### PR DESCRIPTION
## 개요
예매에서 쿠폰, 마일리지 사용 내역을 관리하고 결제 실패시 원복처리 요청을 보냅니다.

## 작업 내용
1. 쿠폰, 마일리지 사용 기록 테이블 생성
2. 결제 실패시 쿠폰, 마일리지 사용 원복 처리 요청
3. 처리 완료 수신시 사용 기록에 환불 됐다는 의미의 refunded 필드를 true 로 변경
### 변경 사항

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
#235

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
