### PR TITLE
#265 <DevOps> Prometheus 설정 개선

### DIFF
--- a/com.taken_seat.common-service/prometheus/prometheus.yml
+++ b/com.taken_seat.common-service/prometheus/prometheus.yml
@@ -6,3 +6,38 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: [ 'host.docker.internal:19091' ]
+
+  - job_name: 'auth-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:19092' ]
+
+  - job_name: 'coupon-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:19093' ]
+
+  - job_name: 'queue-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:19094' ]
+
+  - job_name: 'booking-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:19095' ]
+
+  - job_name: 'performance-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:19096' ]
+
+  - job_name: 'payment-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:19097' ]
+
+  - job_name: 'review-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:19098' ]


### PR DESCRIPTION
## 개요
기존 Prometheus 설정에서는 gateway-service 한 개 서비스만 메트릭 수집 대상이었기 때문에, 나머지 서비스들의 상태나 메트릭을 확인할 수 없었습니다. 운영 및 모니터링의 정확도를 높이기 위해, 각 서비스에 대한 Prometheus 수집 대상을 추가하였습니다.

## 작업 내용
### 변경 사항
- `prometheus.yml`의 `scrape_configs`에 추가
  - `auth-service` (19092)
  - `coupon-service` (19093)
  - `queue-service` (19094)
  - `booking-service` (19095)
  - `performance-service` (19096)
  - `payment-service` (19097)
  - `review-service` (19098)

### 변경 이유

### 추가 설명

## 리뷰 요구사항
- Prometheus UI(`http://localhost:9090`) → **Status > Targets**에서 각 서비스 `UP` 상태 확인
- 각 서비스의 `/actuator/prometheus`에서 메트릭 정상 노출 확인 필요

#### 연관된 이슈
closed #265 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [X] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
