### PR TITLE
#161 <Booking> FeignClient 충돌 해결 및 Auth 도메인에 결제 완료 전송

### DIFF
--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingProducer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingProducer.java
@@ -5,11 +5,13 @@ import com.taken_seat.common_service.message.PaymentMessage;
 import com.taken_seat.common_service.message.UserBenefitMessage;
 
 public interface BookingProducer {
-	void sendPaymentRequestEvent(PaymentMessage message);
+	void sendPaymentRequest(PaymentMessage message);
 
-	void sendPaymentCompleteEvent(TicketRequestMessage message);
+	void sendTicketRequest(TicketRequestMessage message);
 
 	void sendBenefitUsageRequest(UserBenefitMessage message);
 
 	void sendBenefitRefundRequest(UserBenefitMessage message);
+
+	void sendBenefitPaymentResult(UserBenefitMessage message);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/client/PerformanceClient.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/client/PerformanceClient.java
@@ -8,7 +8,7 @@ import com.taken_seat.common_service.dto.ApiResponseData;
 import com.taken_seat.common_service.dto.request.BookingSeatClientRequestDto;
 import com.taken_seat.common_service.dto.response.BookingSeatClientResponseDto;
 
-@FeignClient(name = "performance-service", path = "/api/v1/performancehalls")
+@FeignClient(name = "performance-service", path = "/api/v1/performancehalls", contextId = "booking")
 public interface PerformanceClient {
 
 	@PutMapping("/seat/status")

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaProducer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaProducer.java
@@ -50,6 +50,7 @@ public class BookingKafkaProducer implements BookingProducer {
 		kafkaTemplate.send(BENEFIT_USAGE_REQUEST_TOPIC, message);
 	}
 
+	// TODO: 환불 시도에 사용될 것
 	@Override
 	public void sendBenefitRefundRequest(UserBenefitMessage message) {
 

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaProducer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaProducer.java
@@ -29,14 +29,17 @@ public class BookingKafkaProducer implements BookingProducer {
 	@Value("${kafka.topic.benefit-refund-request}")
 	private String BENEFIT_REFUND_REQUEST_TOPIC;
 
+	@Value("${kafka.topic.benefit-payment-result}")
+	private String BENEFIT_PAYMENT_RESULT_TOPIC;
+
 	@Override
-	public void sendPaymentRequestEvent(PaymentMessage message) {
+	public void sendPaymentRequest(PaymentMessage message) {
 
 		kafkaTemplate.send(PAYMENT_REQUEST_TOPIC, message);
 	}
 
 	@Override
-	public void sendPaymentCompleteEvent(TicketRequestMessage message) {
+	public void sendTicketRequest(TicketRequestMessage message) {
 
 		kafkaTemplate.send(TICKET_REQUEST_TOPIC, message);
 	}
@@ -51,5 +54,11 @@ public class BookingKafkaProducer implements BookingProducer {
 	public void sendBenefitRefundRequest(UserBenefitMessage message) {
 
 		kafkaTemplate.send(BENEFIT_REFUND_REQUEST_TOPIC, message);
+	}
+
+	@Override
+	public void sendBenefitPaymentResult(UserBenefitMessage message) {
+
+		kafkaTemplate.send(BENEFIT_PAYMENT_RESULT_TOPIC, message);
 	}
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/service/BookingServiceImpl.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/service/BookingServiceImpl.java
@@ -258,16 +258,7 @@ public class BookingServiceImpl implements BookingService {
 
 			if (optional.isPresent()) {
 				BenefitUsageHistory benefitUsageHistory = optional.get();
-				UserBenefitMessage benefitMessage = UserBenefitMessage.builder()
-					.bookingId(message.getBookingId())
-					.userId(message.getUserId())
-					.couponId(benefitUsageHistory.getCouponId())
-					.mileage(benefitUsageHistory.getMileage())
-					.price(booking.getPrice())
-					.status(UserBenefitMessage.UserBenefitStatus.FAIL)
-					.build();
-
-				bookingProducer.sendBenefitRefundRequest(benefitMessage);
+				benefitUsageHistory.refunded(message.getUserId());
 			}
 			throw new BookingException(ResponseCode.BOOKING_PAYMENT_FAILED_EXCEPTION);
 		}
@@ -327,6 +318,7 @@ public class BookingServiceImpl implements BookingService {
 		}
 	}
 
+	// TODO: 나중에 환불 시도에 사용될 가능성있음
 	@Override
 	@Transactional
 	public void updateBenefitUsageHistory(UserBenefitMessage message) {

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/infrastructure/client/PerformanceClient.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/ticket/infrastructure/client/PerformanceClient.java
@@ -1,0 +1,20 @@
+package com.taken_seat.booking_service.ticket.infrastructure.client;
+
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.taken_seat.common_service.dto.response.TicketPerformanceClientResponse;
+
+@FeignClient(name = "performance-service", path = "/api/v1/performencetickets", contextId = "ticket")
+public interface PerformanceClient {
+
+	@GetMapping("/{performanceId}/schedules/{performanceScheduleId}/seats/{seatId}")
+	TicketPerformanceClientResponse getPerformanceInfo(
+		@PathVariable("performanceId") UUID performanceId,
+		@PathVariable("performanceScheduleId") UUID performanceScheduleId,
+		@PathVariable("seatId") UUID seatId
+	);
+}

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/message/UserBenefitMessage.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/message/UserBenefitMessage.java
@@ -29,6 +29,7 @@ public class UserBenefitMessage {
 
 	public enum UserBenefitStatus {
 		SUCCESS,
-		FAIL
+		FAIL,
+		REFUND
 	}
 }


### PR DESCRIPTION
## 개요
FeignClient 충돌 해결 및 Auth 도메인에 결제 완료 전송

## 작업 내용
Booking 의 FeignClient 와 Ticket 의 FeignClient 에 contextId 를 추가하여 개별로 식별되도록 했습니다.
Auth 도메인에 benefit.payment.result 로 이벤트를 전송하여 결제 결과를 알려줍니다.
### 변경 사항

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
#161 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
