### PR TITLE
#317 <Performance> 공연 시작 시간 조회 API 구현

### DIFF
--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/response/PerformanceStartTimeDto.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/dto/response/PerformanceStartTimeDto.java
@@ -1,0 +1,6 @@
+package com.taken_seat.common_service.dto.response;
+
+import java.time.LocalDateTime;
+
+public record PerformanceStartTimeDto(LocalDateTime startAt) {
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/application/service/PerformanceService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.taken_seat.common_service.dto.AuthenticatedUser;
+import com.taken_seat.common_service.dto.response.PerformanceStartTimeDto;
 import com.taken_seat.common_service.exception.customException.PerformanceException;
 import com.taken_seat.common_service.exception.enums.ResponseCode;
 import com.taken_seat.performance_service.performance.application.dto.mapper.ResponseMapper;
@@ -182,5 +183,15 @@ public class PerformanceService {
 			}
 		}
 		performanceRepository.save(performance);
+	}
+
+	@Transactional
+	public PerformanceStartTimeDto getPerformanceStartTime(UUID performanceId, UUID performanceScheduleId) {
+		Performance performance = performanceRepository.findById(performanceId)
+			.orElseThrow(() -> new PerformanceException(ResponseCode.PERFORMANCE_NOT_FOUND_EXCEPTION));
+
+		PerformanceSchedule schedule = performance.getScheduleById(performanceScheduleId);
+
+		return new PerformanceStartTimeDto(schedule.getStartAt());
 	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/presentation/controller/PerformanceController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.taken_seat.common_service.dto.ApiResponseData;
 import com.taken_seat.common_service.dto.AuthenticatedUser;
+import com.taken_seat.common_service.dto.response.PerformanceStartTimeDto;
 import com.taken_seat.performance_service.performance.application.dto.request.CreateRequestDto;
 import com.taken_seat.performance_service.performance.application.dto.request.SearchFilterParam;
 import com.taken_seat.performance_service.performance.application.dto.request.UpdateRequestDto;
@@ -83,7 +84,7 @@ public class PerformanceController {
 
 	/**
 	 * 공연 종료 시간 조회 API
-	 * 리뷰 등록하기 전 해당 공연이 종료되었는지 검사하기 위해 종료시간을 받아오는 메서드
+	 * 리뷰 등록하기 전 해당 공연이 종료되었는지 검사하기 위해 종료 시간을 받아오는 메서드
 	 */
 	@GetMapping("/{performanceId}/schedules/{performanceScheduleId}/end-time")
 	ResponseEntity<ApiResponseData<PerformanceEndTimeDto>> getPerformanceEndTime(
@@ -101,5 +102,19 @@ public class PerformanceController {
 
 		performanceService.updateStatus(id, authenticatedUser);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponseData.success());
+	}
+
+	/**
+	 * 공연 시작 시간 조회 API
+	 * 환불 가능 여부를 판단하기 위해 공연 시작 시간을 받아오는 메서드
+	 */
+	@GetMapping("/{performanceId}/schedules/{performanceScheduleId}/start-time")
+	ResponseEntity<ApiResponseData<PerformanceStartTimeDto>> getPerformanceStartTime(
+		@PathVariable("performanceId") UUID performanceId,
+		@PathVariable("performanceScheduleId") UUID performanceScheduleId) {
+
+		PerformanceStartTimeDto response = performanceService.getPerformanceStartTime(performanceId,
+			performanceScheduleId);
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseData.success(response));
 	}
 }


### PR DESCRIPTION
## 개요
환불 요청 가능 여부를 판단하기 위해, 공연 시작 시간을 조회하는 API 구현했습니다.

## 작업 내용
### 변경 사항

1. `PerformanceController.java`  
   - `GET /{performanceId}/schedules/{performanceScheduleId}/start-time` 공연 시작 시간 조회 API 엔드포인트 추가

2. `PerformanceService.java`  
   -  공연 및 공연 스케줄 정보 조회 후 시작 시간(`startAt`) 반환  
   
3. `PerformanceStartTimeDto.java`  
   -  LocalDateTime을 담는 응답 DTO 정의

4. postman 테스트 진행
![image](https://github.com/user-attachments/assets/4cd20f1c-17e4-4e43-8ef7-e4d75e4ee66e)


### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #317 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
