### PR TITLE
#321 <Performance> 공연 및 공연장 결합 제거 및 파사드 패턴 적용

### DIFF
--- a/com.taken_seat.gateway-service/src/main/resources/application.yml
+++ b/com.taken_seat.gateway-service/src/main/resources/application.yml
@@ -30,7 +30,7 @@ spring:
         - id: performance-service
           uri: lb://performance-service
           predicates:
-            - Path=/api/v1/performances/**, /api/v1/performancehalls/**, /performance-service/v3/api-docs
+            - Path=/api/v1/performances/**, /api/v1/performancehalls/**, /api/v1/performencetickets/**, /performance-service/v3/api-docs
           filters:
             - RewritePath=/performance-service/(?<segment>.*), /$\{segment}
 

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/facade/PerformanceFacade.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/facade/PerformanceFacade.java
@@ -1,0 +1,12 @@
+package com.taken_seat.performance_service.performance.domain.facade;
+
+import java.util.UUID;
+
+import com.taken_seat.performance_service.performance.domain.model.Performance;
+
+public interface PerformanceFacade {
+
+	Performance getByPerformanceId(UUID performanceId);
+
+	Performance getByPerformanceScheduleId(UUID performanceId);
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/validator/PerformanceExistenceValidator.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/validator/PerformanceExistenceValidator.java
@@ -1,0 +1,29 @@
+package com.taken_seat.performance_service.performance.domain.validator;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.taken_seat.common_service.exception.customException.PerformanceException;
+import com.taken_seat.common_service.exception.enums.ResponseCode;
+import com.taken_seat.performance_service.performance.domain.model.Performance;
+import com.taken_seat.performance_service.performance.domain.repository.PerformanceRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PerformanceExistenceValidator {
+
+	private final PerformanceRepository performanceRepository;
+
+	public Performance validateByPerformanceId(UUID id) {
+		return performanceRepository.findById(id)
+			.orElseThrow(() -> new PerformanceException(ResponseCode.PERFORMANCE_NOT_FOUND_EXCEPTION));
+	}
+
+	public Performance validateByPerformanceScheduleId(UUID performanceScheduleId) {
+		return performanceRepository.findByPerformanceScheduleId(performanceScheduleId)
+			.orElseThrow(() -> new PerformanceException(ResponseCode.PERFORMANCE_NOT_FOUND_EXCEPTION));
+	}
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/facade/PerformanceFacadeImpl.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/infrastructure/facade/PerformanceFacadeImpl.java
@@ -1,0 +1,28 @@
+package com.taken_seat.performance_service.performance.infrastructure.facade;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.taken_seat.performance_service.performance.domain.facade.PerformanceFacade;
+import com.taken_seat.performance_service.performance.domain.model.Performance;
+import com.taken_seat.performance_service.performance.domain.validator.PerformanceExistenceValidator;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PerformanceFacadeImpl implements PerformanceFacade {
+
+	private final PerformanceExistenceValidator performanceExistenceValidator;
+
+	@Override
+	public Performance getByPerformanceId(UUID performanceId) {
+		return performanceExistenceValidator.validateByPerformanceId(performanceId);
+	}
+
+	@Override
+	public Performance getByPerformanceScheduleId(UUID performanceScheduleId) {
+		return performanceExistenceValidator.validateByPerformanceScheduleId(performanceScheduleId);
+	}
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/facade/PerformanceHallFacade.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/facade/PerformanceHallFacade.java
@@ -1,0 +1,12 @@
+package com.taken_seat.performance_service.performancehall.domain.facade;
+
+import java.util.UUID;
+
+import com.taken_seat.performance_service.performancehall.domain.model.PerformanceHall;
+
+public interface PerformanceHallFacade {
+
+	PerformanceHall getByPerformanceHallId(UUID performanceHallId);
+
+	boolean isSoldOut(UUID performanceHallId);
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/model/PerformanceHall.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/model/PerformanceHall.java
@@ -105,4 +105,9 @@ public class PerformanceHall extends BaseTimeEntity {
 		}
 		this.totalSeats = this.seats.size();
 	}
+
+	public boolean isSoldOut() {
+		return seats.stream()
+			.noneMatch(seat -> seat.getStatus() == SeatStatus.AVAILABLE);
+	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/validation/PerformanceHallExistenceValidator.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/validation/PerformanceHallExistenceValidator.java
@@ -1,0 +1,29 @@
+package com.taken_seat.performance_service.performancehall.domain.validation;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.taken_seat.common_service.exception.customException.PerformanceException;
+import com.taken_seat.common_service.exception.enums.ResponseCode;
+import com.taken_seat.performance_service.performancehall.domain.model.PerformanceHall;
+import com.taken_seat.performance_service.performancehall.domain.repository.PerformanceHallRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PerformanceHallExistenceValidator {
+
+	private final PerformanceHallRepository performanceHallRepository;
+
+	public PerformanceHall validateByPerformanceHallId(UUID performanceHallid) {
+		return performanceHallRepository.findById(performanceHallid)
+			.orElseThrow(() -> new PerformanceException(ResponseCode.PERFORMANCE_HALL_NOT_FOUND_EXCEPTION));
+	}
+
+	public PerformanceHall validateBySeatId(UUID seatId) {
+		return performanceHallRepository.findBySeatId(seatId)
+			.orElseThrow(() -> new PerformanceException(ResponseCode.PERFORMANCE_HALL_NOT_FOUND_EXCEPTION));
+	}
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/infrastructure/facade/PerformanceHallFacadeImpl.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/infrastructure/facade/PerformanceHallFacadeImpl.java
@@ -1,0 +1,30 @@
+package com.taken_seat.performance_service.performancehall.infrastructure.facade;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.taken_seat.performance_service.performancehall.domain.facade.PerformanceHallFacade;
+import com.taken_seat.performance_service.performancehall.domain.model.PerformanceHall;
+import com.taken_seat.performance_service.performancehall.domain.validation.PerformanceHallExistenceValidator;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PerformanceHallFacadeImpl implements PerformanceHallFacade {
+
+	private final PerformanceHallExistenceValidator performanceHallExistenceValidator;
+
+	@Override
+	public PerformanceHall getByPerformanceHallId(UUID performanceHallId) {
+		return performanceHallExistenceValidator.validateByPerformanceHallId(performanceHallId);
+	}
+
+	@Override
+	public boolean isSoldOut(UUID performanceHallId) {
+		PerformanceHall performanceHall = performanceHallExistenceValidator.validateByPerformanceHallId(
+			performanceHallId);
+		return performanceHall.isSoldOut();
+	}
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performenceticket/application/service/PerformenceTicketService.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performenceticket/application/service/PerformenceTicketService.java
@@ -4,12 +4,12 @@ import org.springframework.stereotype.Service;
 
 import com.taken_seat.common_service.dto.request.TicketPerformanceClientRequest;
 import com.taken_seat.common_service.dto.response.TicketPerformanceClientResponse;
+import com.taken_seat.performance_service.performance.domain.facade.PerformanceFacade;
 import com.taken_seat.performance_service.performance.domain.model.Performance;
 import com.taken_seat.performance_service.performance.domain.model.PerformanceSchedule;
-import com.taken_seat.performance_service.performance.domain.repository.PerformanceRepository;
+import com.taken_seat.performance_service.performancehall.domain.facade.PerformanceHallFacade;
 import com.taken_seat.performance_service.performancehall.domain.model.PerformanceHall;
 import com.taken_seat.performance_service.performancehall.domain.model.Seat;
-import com.taken_seat.performance_service.performancehall.domain.repository.PerformanceHallRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,18 +17,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PerformenceTicketService {
 
-	public final PerformanceRepository performanceRepository;
-	public final PerformanceHallRepository performanceHallRepository;
+	public final PerformanceFacade performanceFacade;
+	public final PerformanceHallFacade performanceHallFacade;
 
 	public TicketPerformanceClientResponse getPerformanceInfo(TicketPerformanceClientRequest request) {
 
-		Performance performance = performanceRepository.findById(request.getPerformanceId())
-			.orElseThrow(() -> new IllegalArgumentException("공연 정보가 존재하지 않습니다"));
+		Performance performance = performanceFacade.getByPerformanceId(request.getPerformanceId());
 
 		PerformanceSchedule schedule = performance.getScheduleById(request.getPerformanceScheduleId());
 
-		PerformanceHall performanceHall = performanceHallRepository.findById((schedule.getPerformanceHallId()))
-			.orElseThrow(() -> new IllegalArgumentException("공연장 정보가 존재하지 않습니다"));
+		PerformanceHall performanceHall = performanceHallFacade.getByPerformanceHallId(schedule.getPerformanceHallId());
 
 		Seat seat = performanceHall.getSeatById(request.getSeatId());
 


### PR DESCRIPTION
## 개요
공연 및 공연장 간의 직접적인 의존을 제거하고, 파사드 패턴을 통해 도메인 간 결합도를 낮췄습니다. 
또한 각 도메인의 Validator 클래스를 분리하여 도메인 객체 존재 여부 검증 로직을 명확히 분리했습니다.


## 작업 내용
### 변경 사항

#### 1. 인터페이스 및 구현체 생성
- `PerformanceFacade`, `PerformanceFacadeImpl`  
  → 공연 ID 및 공연 회차 ID 기반 `Performance` 조회
- `PerformanceHallFacade`, `PerformanceHallFacadeImpl`  
  → 공연장 ID 기반 `PerformanceHall` 조회 및 좌석 판매 여부 확인

#### 2. Validator 클래스 생성
- `PerformanceExistenceValidator`  
  → `validateByPerformanceId`, `validateByPerformanceScheduleId`  
- `PerformanceHallExistenceValidator`  
  → `validateByPerformanceHallId`, `validateBySeatId`

#### 3. Service 로직 리팩토링
- `PerformanceService`  
  → 공연 조회 시 `PerformanceExistenceValidator` 사용  
  → 공연장 SOLDOUT 여부 파사드 호출로 변경  
- `PerformanceHallService`  
  → 공연 ID, 회차 ID 직접 조회 제거  
  → `PerformanceFacade`, `PerformanceHallExistenceValidator` 활용

#### 4. 도메인 로직 추가
- `PerformanceHall`  
  → `isSoldOut()` 메서드 추가  
  → 공연장 내 모든 좌석이 SOLDOUT 또는 DISABLED일 경우 true 반환

#### 5. 티켓 패키지 연동 서비스 수정
- `PerformenceTicketService`  
  → 기존 Repository 의존 제거  
  → 공연, 공연장, 좌석 정보 모두 파사드를 통해 조회

#### 6. Gateway.yml 라우팅 설정 추가
- `/api/v1/performencetickets/**`

#### 7. postman test
![image](https://github.com/user-attachments/assets/4cca8c30-f5e6-4af4-8f58-4eed859c4204)
- 해당 API 모두 200, 204 TEST 완료

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #321 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [X] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
