### PR TITLE
#327 <DevOps> CI 빌드 후 GitHub Container Registry에 push 과정 추가

### DIFF
--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -66,7 +66,8 @@ jobs:
         run: |
           ORG_NAME=taken_seat
           MODULE_NAME=$(basename "${{ matrix.module }}" | tr '.' '-' | tr '_' '-')
+          MODULE_PATH=${{ matrix.module }}
           IMAGE_NAME=ghcr.io/${ORG_NAME}/${MODULE_NAME}:latest
 
-          docker build -t $IMAGE_NAME .
+          docker build -t $IMAGE_NAME -f $MODULE_PATH/Dockerfile $MODULE_PATH
           docker push $IMAGE_NAME

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - dev
-      - feature/#327
   pull_request:
     branches:
       - master
@@ -12,9 +11,23 @@ on:
 
 jobs:
   build:
-    name: Multi-Module Build
+    name: Multi-Module Build & Docker Push
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        module:
+          - com.taken_seat.eureka-service
+          - com.taken_seat.common-service
+          - com.taken_seat.auth-service
+          - com.taken_seat.coupon-service
+          - com.taken_seat.queue-service
+          - com.taken_seat.booking-service
+          - com.taken_seat.performance-service
+          - com.taken_seat.payment-service
+          - com.taken_seat.review-service
+          - com.taken_seat.gateway-service
+      fail-fast: false
+      max-parallel: 5
 
     steps:
       - name: 소스 코드 체크아웃
@@ -38,7 +51,16 @@ jobs:
           echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> $GITHUB_ENV
           echo "LOKI_URL=${{ secrets.LOKI_URL }}" >> $GITHUB_ENV
 
-      - name: 전체 모듈 빌드 (병렬 처리)
-        run: ./gradlew build --parallel --no-daemon
-          
-          
+      - name: Gradle 빌드 (서비스 모듈)
+        run: ./gradlew :${{ matrix.module }}:build --parallel --no-daemon
+
+      - name: Docker 로그인 (GitHub Container Registry)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.GITHUB_USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker 이미지 빌드 및 푸시
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}/$(basename ${GITHUB_WORKSPACE})-${{ matrix.module }}:latest .
+          docker push ghcr.io/${{ github.repository }}/$(basename ${GITHUB_WORKSPACE})-${{ matrix.module }}:latest

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Docker 이미지 빌드 및 푸시
         run: |
-          ORG_NAME=taken_seat
+          ORG_NAME=${{ secrets.MY_GITHUB_USERNAME }}  # GitHub 계정명
           MODULE_NAME=$(basename "${{ matrix.module }}" | tr '.' '-' | tr '_' '-')
           MODULE_PATH=${{ matrix.module }}
           IMAGE_NAME=ghcr.io/${ORG_NAME}/${MODULE_NAME}:latest

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - dev
-      - feature/#327
   pull_request:
     branches:
       - master

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Docker 이미지 빌드 및 푸시
         run: |
           ORG_NAME=${{ secrets.MY_GITHUB_USERNAME }}  # GitHub 계정명
-          MODULE_NAME=$(basename "${{ matrix.module }}" | tr '.' '-' | tr '_' '-')
+          MODULE_NAME=$(basename "${{ matrix.module }}" | tr '.' '-' | tr '_' '-'| tr '[:upper:]' '[:lower:]')  # 소문자로 변환
           MODULE_PATH=${{ matrix.module }}
           IMAGE_NAME=ghcr.io/${ORG_NAME}/${MODULE_NAME}:latest
 

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Docker 로그인 (GitHub Container Registry)
         uses: docker/login-action@v2
         with:
+          registry: ghcr.io
           username: ${{ secrets.MY_GITHUB_USERNAME }}
           password: ${{ secrets.MY_GITHUB_TOKEN }}
 

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Docker 로그인 (GitHub Container Registry)
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.GITHUB_USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.MY_GITHUB_USERNAME }}
+          password: ${{ secrets.MY_GITHUB_TOKEN }}
 
       - name: Docker 이미지 빌드 및 푸시
         run: |

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -68,8 +68,6 @@ jobs:
           MODULE_NAME=$(basename "${{ matrix.module }}" | sed 's/com.taken_seat.//')  # com.taken_seat 부분을 제거
           MODULE_PATH=${{ matrix.module }}
           
-            MODULE_NAME=$(echo $MODULE_NAME | tr '-' '.')
-          
           IMAGE_NAME=ghcr.io/${ORG_NAME}/${MODULE_NAME}:latest
 
           docker build -t $IMAGE_NAME -f $MODULE_PATH/Dockerfile $MODULE_PATH

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -68,6 +68,8 @@ jobs:
           MODULE_NAME=$(basename "${{ matrix.module }}" | sed 's/com.taken_seat.//')  # com.taken_seat 부분을 제거
           MODULE_PATH=${{ matrix.module }}
           
+            MODULE_NAME=$(echo $MODULE_NAME | tr '-' '.')
+          
           IMAGE_NAME=ghcr.io/${ORG_NAME}/${MODULE_NAME}:latest
 
           docker build -t $IMAGE_NAME -f $MODULE_PATH/Dockerfile $MODULE_PATH

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Docker 이미지 빌드 및 푸시
         run: |
-          ORG_NAME=taken-seat  # GitHub 계정명
+          ORG_NAME=toolatebro
           MODULE_NAME=$(basename "${{ matrix.module }}" | sed 's/com.taken_seat.//')  # com.taken_seat 부분을 제거
           MODULE_PATH=${{ matrix.module }}
           

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -4,48 +4,17 @@ on:
     branches:
       - master
       - dev
+      - feature/#327
   pull_request:
     branches:
       - master
       - dev
 
 jobs:
-  eureka:
+  build:
+    name: Multi-Module Build
     runs-on: ubuntu-latest
-    steps:
-      - name: 소스 코드 체크아웃
-        uses: actions/checkout@v4
 
-      - name: JDK 17 설정
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Gradle 실행 권한 부여
-        run: chmod +x ./gradlew
-
-      - name: Eureka 서버 빌드
-        run: |
-          ./gradlew :com.taken_seat.eureka-service:bootJar
-
-
-  services:
-    runs-on: ubuntu-latest
-    needs: eureka  # Eureka가 실행된 후 실행
-    strategy:
-      matrix:
-        module:
-          - com.taken_seat.common-service
-          - com.taken_seat.auth-service
-          - com.taken_seat.coupon-service
-          - com.taken_seat.queue-service
-          - com.taken_seat.booking-service
-          - com.taken_seat.performance-service
-          - com.taken_seat.payment-service
-          - com.taken_seat.review-service
-      fail-fast: false
-      max-parallel: 5
 
     steps:
       - name: 소스 코드 체크아웃
@@ -69,24 +38,7 @@ jobs:
           echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> $GITHUB_ENV
           echo "LOKI_URL=${{ secrets.LOKI_URL }}" >> $GITHUB_ENV
 
-      - name: Gradle 빌드 (서비스 모듈)
-        run: ./gradlew :${{ matrix.module }}:build --parallel --no-daemon
-
-  gateway:
-    runs-on: ubuntu-latest
-    needs: services  # 모든 서비스 모듈이 빌드된 후 실행
-    steps:
-      - name: 소스 코드 체크아웃
-        uses: actions/checkout@v4
-
-      - name: JDK 17 설정
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Gradle 실행 권한 부여
-        run: chmod +x ./gradlew
-
-      - name: Gradle 빌드 (Gateway)
-        run: ./gradlew :com.taken_seat.gateway-service:build --no-daemon
+      - name: 전체 모듈 빌드 (병렬 처리)
+        run: ./gradlew build --parallel --no-daemon
+          
+          

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -64,5 +64,8 @@ jobs:
 
       - name: Docker 이미지 빌드 및 푸시
         run: |
-          docker build -t ghcr.io/${{ github.repository }}/$(basename ${GITHUB_WORKSPACE})-${{ matrix.module }}:latest .
-          docker push ghcr.io/${{ github.repository }}/$(basename ${GITHUB_WORKSPACE})-${{ matrix.module }}:latest
+          REPO_NAME=$(basename ${GITHUB_WORKSPACE} | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME=ghcr.io/${{ github.repository_owner }}/${REPO_NAME}-${{ matrix.module }}:latest
+
+          docker build -t $IMAGE_NAME .
+          docker push $IMAGE_NAME

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -65,8 +65,12 @@ jobs:
       - name: Docker 이미지 빌드 및 푸시
         run: |
           ORG_NAME=${{ secrets.MY_GITHUB_USERNAME }}  # GitHub 계정명
-          MODULE_NAME=$(basename "${{ matrix.module }}" | tr '.' '-' | tr '_' '-'| tr '[:upper:]' '[:lower:]')  # 소문자로 변환
+          MODULE_NAME=$(basename "${{ matrix.module }}" | sed 's/com.taken_seat.//')  # com.taken_seat 부분을 제거
           MODULE_PATH=${{ matrix.module }}
+          
+          # 이미지 이름에서 하이픈을 언더스코어로 변환 (선택적)
+          MODULE_NAME=$(echo $MODULE_NAME | tr '-' '_')
+
           IMAGE_NAME=ghcr.io/${ORG_NAME}/${MODULE_NAME}:latest
 
           docker build -t $IMAGE_NAME -f $MODULE_PATH/Dockerfile $MODULE_PATH

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -68,9 +68,6 @@ jobs:
           MODULE_NAME=$(basename "${{ matrix.module }}" | sed 's/com.taken_seat.//')  # com.taken_seat 부분을 제거
           MODULE_PATH=${{ matrix.module }}
           
-          # 이미지 이름에서 하이픈을 언더스코어로 변환 (선택적)
-          MODULE_NAME=$(echo $MODULE_NAME | tr '-' '_')
-
           IMAGE_NAME=ghcr.io/${ORG_NAME}/${MODULE_NAME}:latest
 
           docker build -t $IMAGE_NAME -f $MODULE_PATH/Dockerfile $MODULE_PATH

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - dev
+      - feature/#327
   pull_request:
     branches:
       - master

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -14,8 +14,9 @@ jobs:
   build:
     name: Multi-Module Build & Docker Push
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
+
+    strategy: # 각 서비스 모듈에 대해 병렬로 빌드를 진행
+      matrix: # 여기서 정의된 모듈들에 대해 각각 빌드 작업을 실행
         module:
           - com.taken_seat.eureka-service
           - com.taken_seat.common-service
@@ -27,12 +28,12 @@ jobs:
           - com.taken_seat.payment-service
           - com.taken_seat.review-service
           - com.taken_seat.gateway-service
-      fail-fast: false
-      max-parallel: 5
+      fail-fast: true  # 하나의 작업이 실패하면 나머지 작업 취소
+      max-parallel: 5 # 최대 5개의 모듈을 병렬로 빌드 진행
 
     steps:
       - name: 소스 코드 체크아웃
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4 # GitHub Actions에서 제공하는 `checkout` 액션 사용
 
       - name: JDK 17 설정
         uses: actions/setup-java@v3
@@ -43,7 +44,7 @@ jobs:
       - name: Gradle 실행 권한 부여
         run: chmod +x ./gradlew
 
-      - name: 환경 변수 설정
+      - name: 환경 변수 설정   # Docker 빌드 및 실행에 필요한 환경 변수 설정
         run: |
           echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }}" >> $GITHUB_ENV
           echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }}" >> $GITHUB_ENV
@@ -52,23 +53,26 @@ jobs:
           echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> $GITHUB_ENV
           echo "LOKI_URL=${{ secrets.LOKI_URL }}" >> $GITHUB_ENV
 
-      - name: Gradle 빌드 (서비스 모듈)
-        run: ./gradlew :${{ matrix.module }}:build --parallel --no-daemon
+      - name: Gradle 빌드 (서비스 모듈) # 각 모듈에 대해 Gradle 빌드를 실행
+        run: ./gradlew :${{ matrix.module }}:build --parallel --no-daemon # 병렬로 빌드 실행
 
-      - name: Docker 로그인 (GitHub Container Registry)
-        uses: docker/login-action@v2
+      - name: Docker 로그인 (GitHub Container Registry)  # GitHub Container Registry에 로그인
+        uses: docker/login-action@v2 # `docker/login-action` 사용
         with:
-          registry: ghcr.io
+          registry: ghcr.io # GitHub Container Registry URL
           username: ${{ secrets.MY_GITHUB_USERNAME }}
           password: ${{ secrets.MY_GITHUB_TOKEN }}
 
       - name: Docker 이미지 빌드 및 푸시
         run: |
-          ORG_NAME=toolatebro
-          MODULE_NAME=$(basename "${{ matrix.module }}" | sed 's/com.taken_seat.//')  # com.taken_seat 부분을 제거
+          ORG_NAME=toolatebro # Docker 이미지의 조직 이름 설정
+          MODULE_NAME=$(basename "${{ matrix.module }}" | sed 's/com.taken_seat.//') # 모듈 이름에서 접두어 제거
           MODULE_PATH=${{ matrix.module }}
           
-          IMAGE_NAME=ghcr.io/${ORG_NAME}/${MODULE_NAME}:latest
-
+          IMAGE_NAME=ghcr.io/${ORG_NAME}/${MODULE_NAME}:latest # Docker 이미지 이름 설정
+          
+          # Docker 이미지 빌드 명령어 실행
           docker build -t $IMAGE_NAME -f $MODULE_PATH/Dockerfile $MODULE_PATH
+          
+          # Docker 이미지를 GitHub Container Registry에 푸시
           docker push $IMAGE_NAME

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Docker 이미지 빌드 및 푸시
         run: |
-          ORG_NAME=${{ secrets.MY_GITHUB_USERNAME }}  # GitHub 계정명
+          ORG_NAME=taken-seat  # GitHub 계정명
           MODULE_NAME=$(basename "${{ matrix.module }}" | sed 's/com.taken_seat.//')  # com.taken_seat 부분을 제거
           MODULE_PATH=${{ matrix.module }}
           

--- a/.github/workflows/deploay.yml
+++ b/.github/workflows/deploay.yml
@@ -64,8 +64,9 @@ jobs:
 
       - name: Docker 이미지 빌드 및 푸시
         run: |
-          REPO_NAME=$(basename ${GITHUB_WORKSPACE} | tr '[:upper:]' '[:lower:]')
-          IMAGE_NAME=ghcr.io/${{ github.repository_owner }}/${REPO_NAME}-${{ matrix.module }}:latest
+          ORG_NAME=taken_seat
+          MODULE_NAME=$(basename "${{ matrix.module }}" | tr '.' '-' | tr '_' '-')
+          IMAGE_NAME=ghcr.io/${ORG_NAME}/${MODULE_NAME}:latest
 
           docker build -t $IMAGE_NAME .
           docker push $IMAGE_NAME


### PR DESCRIPTION
## 개요
자동 배포를 위한 이미지 빌드 및 푸시 과정을 추가했습니다.

## 작업 내용
### 변경 사항
- 병렬 빌드 진행중 하나의 빌드가 실패되면 전부 실패되게 변경 ( ci 시간 단축 )
- ci 과정이 정상적으로 처리되고나면 이미지를 빌드해 GitHub Container Registry에 push 합니다.
  -  빌드가 성공된 이미지는 toolatebro 조직의 packages에서 확인할 수 있습니다.
  - 확인 잘 부탁드립니다.

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #327 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
