### PR TITLE
#161 <Booking> 대기열 연계 기능 추가

### DIFF
--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/dto/response/SeatLayoutResponseDto.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/dto/response/SeatLayoutResponseDto.java
@@ -1,0 +1,32 @@
+package com.taken_seat.booking_service.booking.application.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SeatLayoutResponseDto {
+
+	private List<SeatDto> seats;
+
+	@Getter
+	@NoArgsConstructor
+	public class SeatDto {
+		private UUID seatId;
+		private String rowNumber;
+		private String seatNumber;
+		private SeatType seatType;
+		private SeatStatus status;
+
+		public enum SeatType {
+			VIP, R, S, A
+		}
+
+		public enum SeatStatus {
+			AVAILABLE, SOLDOUT, DISABLED
+		}
+	}
+}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingClientService.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingClientService.java
@@ -2,6 +2,7 @@ package com.taken_seat.booking_service.booking.application.service;
 
 import java.util.UUID;
 
+import com.taken_seat.booking_service.booking.application.dto.response.SeatLayoutResponseDto;
 import com.taken_seat.common_service.dto.request.BookingSeatClientRequestDto;
 import com.taken_seat.common_service.dto.response.BookingSeatClientResponseDto;
 import com.taken_seat.common_service.dto.response.BookingStatusDto;
@@ -15,4 +16,6 @@ public interface BookingClientService {
 	BookingSeatClientResponseDto cancelSeatStatus(BookingSeatClientRequestDto requestDto);
 
 	PerformanceStartTimeDto getPerformanceStartTime(UUID performanceId, UUID performanceScheduleId);
+
+	SeatLayoutResponseDto getSeatLayout(UUID performanceScheduleId);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingProducer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingProducer.java
@@ -3,6 +3,7 @@ package com.taken_seat.booking_service.booking.application.service;
 import com.taken_seat.booking_service.common.message.TicketRequestMessage;
 import com.taken_seat.common_service.message.PaymentMessage;
 import com.taken_seat.common_service.message.PaymentRefundMessage;
+import com.taken_seat.common_service.message.QueueEnterMessage;
 import com.taken_seat.common_service.message.UserBenefitMessage;
 
 public interface BookingProducer {
@@ -15,4 +16,6 @@ public interface BookingProducer {
 	void sendBenefitRefundRequest(UserBenefitMessage message);
 
 	void sendPaymentRefundRequest(PaymentRefundMessage message);
+
+	void sendQueueEnterResponse(QueueEnterMessage message);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingService.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingService.java
@@ -12,6 +12,7 @@ import com.taken_seat.booking_service.booking.application.dto.response.BookingCr
 import com.taken_seat.booking_service.booking.application.dto.response.BookingPageResponse;
 import com.taken_seat.booking_service.booking.application.dto.response.BookingReadResponse;
 import com.taken_seat.common_service.dto.AuthenticatedUser;
+import com.taken_seat.common_service.message.BookingRequestMessage;
 import com.taken_seat.common_service.message.PaymentMessage;
 import com.taken_seat.common_service.message.PaymentRefundMessage;
 import com.taken_seat.common_service.message.UserBenefitMessage;
@@ -42,4 +43,6 @@ public interface BookingService {
 	void expireBooking(UUID bookingId);
 
 	void updateBenefitUsageHistory(UserBenefitMessage message);
+
+	void acceptFromQueue(BookingRequestMessage message);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/client/PerformanceClient.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/client/PerformanceClient.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import com.taken_seat.booking_service.booking.application.dto.response.SeatLayoutResponseDto;
 import com.taken_seat.common_service.dto.ApiResponseData;
 import com.taken_seat.common_service.dto.request.BookingSeatClientRequestDto;
 import com.taken_seat.common_service.dto.response.BookingSeatClientResponseDto;
@@ -24,5 +25,9 @@ public interface PerformanceClient {
 
 	@GetMapping("/performances/{performanceId}/schedules/{performanceScheduleId}/start-time")
 	ApiResponseData<PerformanceStartTimeDto> getPerformanceStartTime(@PathVariable("performanceId") UUID performanceId,
+		@PathVariable("performanceScheduleId") UUID performanceScheduleId);
+
+	@GetMapping("/performancehalls/seats/{performanceScheduleId}")
+	ApiResponseData<SeatLayoutResponseDto> getSeatLayout(
 		@PathVariable("performanceScheduleId") UUID performanceScheduleId);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaConsumer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaConsumer.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 
 import com.taken_seat.booking_service.booking.application.service.BookingService;
 import com.taken_seat.booking_service.booking.presentation.BookingConsumer;
+import com.taken_seat.common_service.message.BookingRequestMessage;
 import com.taken_seat.common_service.message.PaymentMessage;
 import com.taken_seat.common_service.message.PaymentRefundMessage;
 import com.taken_seat.common_service.message.UserBenefitMessage;
@@ -42,5 +43,12 @@ public class BookingKafkaConsumer implements BookingConsumer {
 	public void updateBenefitUsageHistory(UserBenefitMessage message) {
 
 		bookingService.updateBenefitUsageHistory(message);
+	}
+
+	@Override
+	@KafkaListener(topics = "${kafka.topic.queue-request}", groupId = "${kafka.consumer.group-id.booking-service}")
+	public void acceptFromQueue(BookingRequestMessage message) {
+
+		bookingService.acceptFromQueue(message);
 	}
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaProducer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaProducer.java
@@ -8,6 +8,7 @@ import com.taken_seat.booking_service.booking.application.service.BookingProduce
 import com.taken_seat.booking_service.common.message.TicketRequestMessage;
 import com.taken_seat.common_service.message.PaymentMessage;
 import com.taken_seat.common_service.message.PaymentRefundMessage;
+import com.taken_seat.common_service.message.QueueEnterMessage;
 import com.taken_seat.common_service.message.UserBenefitMessage;
 
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,9 @@ public class BookingKafkaProducer implements BookingProducer {
 
 	@Value("${kafka.topic.payment-refund-request}")
 	private String PAYMENT_REFUND_REQUEST_TOPIC;
+
+	@Value("${kafka.topic.queue-response}")
+	private String QUEUE_RESPONSE_TOPIC;
 
 	@Override
 	public void sendPaymentRequest(PaymentMessage message) {
@@ -61,5 +65,11 @@ public class BookingKafkaProducer implements BookingProducer {
 	public void sendPaymentRefundRequest(PaymentRefundMessage message) {
 
 		kafkaTemplate.send(PAYMENT_REFUND_REQUEST_TOPIC, message);
+	}
+
+	@Override
+	public void sendQueueEnterResponse(QueueEnterMessage message) {
+
+		kafkaTemplate.send(QUEUE_RESPONSE_TOPIC, message);
 	}
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/service/BookingClientServiceImpl.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/service/BookingClientServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
+import com.taken_seat.booking_service.booking.application.dto.response.SeatLayoutResponseDto;
 import com.taken_seat.booking_service.booking.application.service.BookingClientService;
 import com.taken_seat.booking_service.booking.domain.Booking;
 import com.taken_seat.booking_service.booking.domain.repository.BookingRepository;
@@ -51,6 +52,13 @@ public class BookingClientServiceImpl implements BookingClientService {
 	public PerformanceStartTimeDto getPerformanceStartTime(UUID performanceId, UUID performanceScheduleId) {
 		ApiResponseData<PerformanceStartTimeDto> response = performanceClient.getPerformanceStartTime(performanceId,
 			performanceScheduleId);
+
+		return response.body();
+	}
+
+	@Override
+	public SeatLayoutResponseDto getSeatLayout(UUID performanceScheduleId) {
+		ApiResponseData<SeatLayoutResponseDto> response = performanceClient.getSeatLayout(performanceScheduleId);
 
 		return response.body();
 	}

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/presentation/BookingConsumer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/presentation/BookingConsumer.java
@@ -1,5 +1,6 @@
 package com.taken_seat.booking_service.booking.presentation;
 
+import com.taken_seat.common_service.message.BookingRequestMessage;
 import com.taken_seat.common_service.message.PaymentMessage;
 import com.taken_seat.common_service.message.PaymentRefundMessage;
 import com.taken_seat.common_service.message.UserBenefitMessage;
@@ -12,4 +13,6 @@ public interface BookingConsumer {
 	void createPayment(UserBenefitMessage message);
 
 	void updateBenefitUsageHistory(UserBenefitMessage message);
+
+	void acceptFromQueue(BookingRequestMessage message);
 }

--- a/com.taken_seat.booking-service/src/main/resources/application.yml
+++ b/com.taken_seat.booking-service/src/main/resources/application.yml
@@ -55,6 +55,8 @@ kafka:
     payment-response: payment.response
     ticket-reissue-request: ticket.reissue.request
     ticket-request: ticket.request
+    queue-request: waitingQueue.request
+    queue-response: waitingQueue.response
   consumer:
     group-id:
       booking-service: booking-service

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/message/QueueEnterMessage.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/message/QueueEnterMessage.java
@@ -1,0 +1,17 @@
+package com.taken_seat.common_service.message;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@NoArgsConstructor
+public class QueueEnterMessage {
+	private UUID performanceId;
+	private UUID performanceScheduleId;
+}


### PR DESCRIPTION
## 개요
waitingQueue.request 메시지를 받아서 임의의 좌석으로 예매를 진행하고, 다시 waitingQueue.response 로 대기열 진입 요청을 전송합니다.

## 작업 내용
### 변경 사항

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
#161

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
