### PR TITLE
#250 <Performance> 좌석 상태 변경 시 공연 회차 상태 자동 갱신

### DIFF
--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performance/domain/model/Performance.java
@@ -117,4 +117,9 @@ public class Performance extends BaseTimeEntity {
 	public void updateStatus(PerformanceStatus newStatus) {
 		this.status = newStatus;
 	}
+
+	public void updateScheduleStatus(UUID performanceScheduleId, PerformanceScheduleStatus newStatus) {
+		PerformanceSchedule schedule = getScheduleById(performanceScheduleId);
+		schedule.updateStatus(newStatus);
+	}
 }

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/application/event/SeatStatusEventHandler.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/application/event/SeatStatusEventHandler.java
@@ -1,0 +1,48 @@
+package com.taken_seat.performance_service.performancehall.application.event;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.taken_seat.performance_service.performance.domain.facade.PerformanceFacade;
+import com.taken_seat.performance_service.performance.domain.model.Performance;
+import com.taken_seat.performance_service.performance.domain.model.PerformanceScheduleStatus;
+import com.taken_seat.performance_service.performancehall.domain.event.SeatStatusChangedEvent;
+import com.taken_seat.performance_service.performancehall.domain.model.SeatStatus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeatStatusEventHandler {
+
+	private final PerformanceFacade performanceFacade;
+
+	@EventListener
+	@Transactional
+	public void handleSeatStatusChangedEvent(SeatStatusChangedEvent seatStatusChangedEvent) {
+
+		log.info(
+			"[Performance] 도메인 이벤트 - 좌석 상태 변경 이벤트 수신 완료 → performanceId={}, scheduleId={}, seatId={}, status={}",
+			seatStatusChangedEvent.performanceId(), seatStatusChangedEvent.performanceScheduleId(),
+			seatStatusChangedEvent.seatId(), seatStatusChangedEvent.newStatus());
+
+		Performance performance = performanceFacade.getByPerformanceId(
+			seatStatusChangedEvent.performanceId()
+		);
+
+		if (seatStatusChangedEvent.newStatus() == SeatStatus.SOLDOUT) {
+			performance.updateScheduleStatus(
+				seatStatusChangedEvent.performanceScheduleId(),
+				PerformanceScheduleStatus.SOLDOUT
+			);
+		} else if (seatStatusChangedEvent.newStatus() == SeatStatus.AVAILABLE) {
+			performance.updateScheduleStatus(
+				seatStatusChangedEvent.performanceScheduleId(),
+				PerformanceScheduleStatus.ONSALE
+			);
+		}
+	}
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/application/event/SeatStatusEventPublisher.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/application/event/SeatStatusEventPublisher.java
@@ -1,0 +1,35 @@
+package com.taken_seat.performance_service.performancehall.application.event;
+
+import java.util.UUID;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import com.taken_seat.performance_service.performancehall.domain.event.SeatStatusChangedEvent;
+import com.taken_seat.performance_service.performancehall.domain.model.SeatStatus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeatStatusEventPublisher {
+
+	private final ApplicationEventPublisher applicationEventPublisher;
+
+	public void publish(
+		UUID performanceId,
+		UUID performanceScheduleId,
+		UUID seatId,
+		SeatStatus newStatus
+	) {
+
+		log.info("[performance] 도메인 이벤트 - 좌석 상태 변경 이벤트 발행 → performanceId={}, scheduleId={}, seatId={}, status={}",
+			performanceId, performanceScheduleId, seatId, newStatus);
+
+		SeatStatusChangedEvent event =
+			new SeatStatusChangedEvent(performanceId, performanceScheduleId, seatId, newStatus);
+		applicationEventPublisher.publishEvent(event);
+	}
+}

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/event/SeatStatusChangedEvent.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/performancehall/domain/event/SeatStatusChangedEvent.java
@@ -1,0 +1,13 @@
+package com.taken_seat.performance_service.performancehall.domain.event;
+
+import java.util.UUID;
+
+import com.taken_seat.performance_service.performancehall.domain.model.SeatStatus;
+
+public record SeatStatusChangedEvent(
+	UUID performanceId,
+	UUID performanceScheduleId,
+	UUID seatId,
+	SeatStatus newStatus
+) {
+}


### PR DESCRIPTION
## 개요
공연 회차 상태 변경을 위한 도메인 이벤트 구조를 도입하였습니다.  
예매 생성 및 취소 시 좌석 상태 변경을 감지하여, 해당 공연 회차 상태를 자동으로 갱신합니다.

## 작업 내용  

### 변경 사항  

#### 도메인 이벤트 정의
   - `SeatStatusChangedEvent` 레코드 클래스 생성  
     → 공연 ID, 공연 회차 ID, 좌석 ID, 새로운 좌석 상태 정보를 포함  

#### 이벤트 발행 Publisher 생성
   - `SeatStatusEventPublisher` 클래스 추가  
     → 좌석 상태 변경 후 도메인 서비스(PerformanceHallService)에서 이벤트 발행 담당  
     → `ApplicationEventPublisher` 사용하여 이벤트 시스템 연동  

#### 이벤트 핸들러 등록
   - `SeatStatusEventHandler` 클래스 추가  
     → `@EventListener` 기반 이벤트 수신 후 공연 도메인 퍼사드를 통해 상태 업데이트 처리  
     → 좌석 상태 `SOLDOUT`일 경우 회차 상태 `SOLDOUT`,  
     → `AVAILABLE`일 경우 회차 상태 `ONSALE`로 갱신

#### Performance 도메인 메서드 추가
   - `Performance.updateScheduleStatus(UUID scheduleId, PerformanceScheduleStatus newStatus)`  
     → 회차 ID 기준으로 상태를 직접 갱신할 수 있도록 도메인 메서드 정의  

#### Service 수정
   - `PerformanceHallService.updateSeatStatus(...)`, `cancelSeatStatus(...)`  
     → 좌석 상태 변경 후 `SeatStatusChangedEvent` 발행 추가  
     → 공연 도메인과의 의존성을 직접 연결하지 않고 이벤트 기반으로 연결  

#### postman 테스트 완료
![image](https://github.com/user-attachments/assets/59ac518a-8f63-4fc9-adc2-a0002ac6733e)
![image](https://github.com/user-attachments/assets/3cbcd897-425f-4277-b655-b8d293edec0d)


### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #250

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
