### PR TITLE
#439 <Queue> 대기열 인원 중복 방지

### DIFF
--- a/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/infrastructure/repository/QueueRepository.java
+++ b/com.taken_seat.queue-service/src/main/java/com/taken_seat/queue_service/infrastructure/repository/QueueRepository.java
@@ -56,17 +56,17 @@ public class QueueRepository {
 
 
     //Set
-    public Long addUser(String performanceId, String token) {
-        return redisTemplate.opsForSet().add(USER_NAMESPACE + performanceId, token);
+    public Long addUser(String token) {
+        return redisTemplate.opsForSet().add(USER_NAMESPACE, token);
     }
 
     //유저가 이미 대기열에 있는지 확인
-    public Boolean setIsMember(String performanceId, String token) {
-        return redisTemplate.opsForSet().isMember(USER_NAMESPACE + performanceId, token);
+    public Boolean setIsMember(String token) {
+        return redisTemplate.opsForSet().isMember(USER_NAMESPACE, token);
     }
 
-    public void deleteUserSet(String performanceId) {
-        redisTemplate.delete(USER_NAMESPACE + performanceId);
+    public void removeUser(String token) {
+        redisTemplate.opsForSet().remove(USER_NAMESPACE, token);
     }
 
     //공연Id 관리


### PR DESCRIPTION
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 작업 내용
### 변경 사항
- 동일한 계정으로 여러 대기열에 입장하는 것 방지
- Queue Repository 인원 관리 Set에서 Key 삭제
- Kafka 이벤트 전송 시 인원 관리 Set에서 인원 삭제
- 새 대기열 입장 시 기존 대기열에서 나가게 된 후 새 대기열 맨 뒤로 입장

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #439 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
