### PR TITLE
<DevOps> 모니터링 알림 설정을 위한 management.metrics.tags.service 추가

### DIFF
--- a/com.taken_seat.auth-service/src/main/resources/application.yml
+++ b/com.taken_seat.auth-service/src/main/resources/application.yml
@@ -65,6 +65,7 @@ management:
   metrics:
     tags:
       application: auth-service
+      service: auth-service
   endpoint:
     health:
       show-details: always

--- a/com.taken_seat.booking-service/src/main/resources/application.yml
+++ b/com.taken_seat.booking-service/src/main/resources/application.yml
@@ -29,6 +29,7 @@ management:
   metrics:
     tags:
       application: booking-service
+      service: booking-service
   zipkin:
     tracing:
       endpoint: ${ZIPKIN_ENDPOINT}

--- a/com.taken_seat.coupon-service/src/main/resources/application.yml
+++ b/com.taken_seat.coupon-service/src/main/resources/application.yml
@@ -59,6 +59,7 @@ management:
   metrics:
     tags:
       application: coupon-service
+      service: coupon-service
   zipkin:
     tracing:
       endpoint: ${ZIPKIN_ENDPOINT}

--- a/com.taken_seat.gateway-service/src/main/resources/application.yml
+++ b/com.taken_seat.gateway-service/src/main/resources/application.yml
@@ -113,6 +113,7 @@ management:
   metrics:
     tags:
       application: gateway-service
+      service: gateway-service
   endpoint:
     health:
       show-details: always

--- a/com.taken_seat.payment-service/src/main/resources/application.yml
+++ b/com.taken_seat.payment-service/src/main/resources/application.yml
@@ -36,6 +36,7 @@ management:
   metrics:
     tags:
       application: payment-service
+      service: payment-service
   zipkin:
     tracing:
       endpoint: ${ZIPKIN_ENDPOINT}

--- a/com.taken_seat.performance-service/src/main/resources/application.yml
+++ b/com.taken_seat.performance-service/src/main/resources/application.yml
@@ -40,6 +40,7 @@ management:
   metrics:
     tags:
       application: performance-service
+      service: performance-service
 
   zipkin:
     tracing:

--- a/com.taken_seat.queue-service/src/main/resources/application.yml
+++ b/com.taken_seat.queue-service/src/main/resources/application.yml
@@ -30,8 +30,6 @@ kafka:
   consumer:
     group-id: waitingQueue
 
-
-
 eureka:
   client:
     service-url:
@@ -43,6 +41,7 @@ management:
   metrics:
     tags:
       application: queue-service
+      service: queue-service
   zipkin:
     tracing:
       endpoint: ${ZIPKIN_ENDPOINT}

--- a/com.taken_seat.review-service/src/main/resources/application.yml
+++ b/com.taken_seat.review-service/src/main/resources/application.yml
@@ -36,6 +36,7 @@ management:
   metrics:
     tags:
       application: review-service
+      service: review-service
   zipkin:
     tracing:
       endpoint: ${ZIPKIN_ENDPOINT}


### PR DESCRIPTION
## 개요
모니터링 알림 설정을 위한 management.metrics.tags.service 추가

## 작업 내용
### 변경 사항
#### application.yml
- management.metrics.tags.service 추가 
- service="{각 도메인}-service" 라벨이 모든 Prometheus 메트릭에 자동 부착

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [X] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
