### PR TITLE
#161 <Booking> 프로메테우스 연결 및 대기열 좌석검사 로직 추가

### DIFF
--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/service/BookingCommandService.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/service/BookingCommandService.java
@@ -586,6 +586,10 @@ public class BookingCommandService {
 			.map(SeatLayoutResponseDto.ScheduleSeatResponseDto::scheduleSeatId)
 			.toList();
 
+		if (seatIds.isEmpty()) {
+			throw new BookingException(ResponseCode.BOOKING_SEAT_NONE_AVAILABLE_EXCEPTION);
+		}
+
 		Random random = new Random();
 		int i = random.nextInt(seatIds.size());
 		UUID seatId = seatIds.get(i);

--- a/com.taken_seat.booking-service/src/main/resources/application.yml
+++ b/com.taken_seat.booking-service/src/main/resources/application.yml
@@ -4,20 +4,17 @@ server:
 spring:
   application:
     name: booking-service
-
   data:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       username: ${REDIS_USERNAME}
       password: ${REDIS_PASSWORD}
-
   datasource:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME}
-
   jpa:
     hibernate:
       ddl-auto: create
@@ -26,6 +23,13 @@ spring:
         format_sql: true
 
 management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: always
   metrics:
     tags:
       application: booking-service

--- a/com.taken_seat.booking-service/src/main/resources/application.yml
+++ b/com.taken_seat.booking-service/src/main/resources/application.yml
@@ -73,7 +73,7 @@ kafka:
 variable:
   lock-wait-time: 3 # 초
   lock-lease-time: 5 # 초
-  booking-expiration-time: 600 # 초
+  booking-expiration-time: 180 # 초
   cache-duration: 600 # 초
 
 common:

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/exception/enums/ResponseCode.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/exception/enums/ResponseCode.java
@@ -95,6 +95,7 @@ public enum ResponseCode {
 	BOOKING_SEAT_CANCEL_FAILED_EXCEPTION(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "좌석 취소를 실패했습니다."),
 	BOOKING_SEAT_LOCKED_EXCEPTION(HttpStatus.OK, HttpStatus.OK.value(), "이미 예약중인 좌석입니다."),
 	BOOKING_SEAT_RESERVED_EXCEPTION(HttpStatus.OK, HttpStatus.OK.value(), "이미 선점된 좌석입니다."),
+	BOOKING_SEAT_NONE_AVAILABLE_EXCEPTION(HttpStatus.OK, HttpStatus.OK.value(), "사용 가능한 좌석이 없습니다."),
 	TICKET_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당 티켓은 존재하지 않습니다."),
 	TICKET_DUPLICATED_EXCEPTION(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "이미 티켓이 존재합니다."),
 


### PR DESCRIPTION
## 개요
프로메테우스 엔드포인트 노출 및 대기열에서 예매로 넘어올 때 가능한 좌석이 없다면 예외를 반환하는 로직을 추가했습니다.

## 작업 내용
### 변경 사항

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
#161

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
