### PR TITLE
feat: #476 [Booking] 사용자의 공연 예매 횟수 기능 추가

### DIFF
--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingProducer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/application/service/BookingProducer.java
@@ -4,23 +4,26 @@ import java.util.UUID;
 
 import com.taken_seat.booking_service.booking.application.dto.event.BookingEntityEvent;
 import com.taken_seat.booking_service.common.message.TicketRequestMessage;
+import com.taken_seat.common_service.message.BookingCompletedMessage;
 import com.taken_seat.common_service.message.PaymentMessage;
 import com.taken_seat.common_service.message.PaymentRefundMessage;
 import com.taken_seat.common_service.message.QueueEnterMessage;
 import com.taken_seat.common_service.message.UserBenefitMessage;
 
 public interface BookingProducer {
-	void sendPaymentRequest(PaymentMessage message);
+	void sendPaymentMessage(PaymentMessage message);
 
-	void sendTicketRequest(TicketRequestMessage message);
+	void sendTicketRequestMessage(TicketRequestMessage message);
 
-	void sendBenefitUsageRequest(UserBenefitMessage message);
+	void sendBenefitUsageMessage(UserBenefitMessage message);
 
-	void sendBenefitRefundRequest(UserBenefitMessage message);
+	void sendBenefitRefundMessage(UserBenefitMessage message);
 
-	void sendPaymentRefundRequest(PaymentRefundMessage message);
+	void sendPaymentRefundMessage(PaymentRefundMessage message);
 
-	void sendQueueEnterResponse(QueueEnterMessage message);
+	void sendQueueEnterMessage(QueueEnterMessage message);
+
+	void sendBookingCompletedMessage(BookingCompletedMessage message);
 
 	void sendBookingExpireEvent(UUID bookingId);
 

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/domain/repository/BookingCommandRepository.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/domain/repository/BookingCommandRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.taken_seat.booking_service.booking.domain.BookingCommand;
+import com.taken_seat.booking_service.booking.domain.BookingStatus;
 
 public interface BookingCommandRepository {
 	Optional<BookingCommand> findByIdAndUserId(UUID id, UUID userId);
@@ -13,4 +14,6 @@ public interface BookingCommandRepository {
 	BookingCommand save(BookingCommand bookingCommand);
 
 	Optional<BookingCommand> findById(UUID id);
+
+	int countByUserIdAndPerformanceIdAndBookingStatus(UUID userId, UUID performanceId, BookingStatus bookingStatus);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaProducer.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/messaging/BookingKafkaProducer.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import com.taken_seat.booking_service.booking.application.dto.event.BookingEntityEvent;
 import com.taken_seat.booking_service.booking.application.service.BookingProducer;
 import com.taken_seat.booking_service.common.message.TicketRequestMessage;
+import com.taken_seat.common_service.message.BookingCompletedMessage;
 import com.taken_seat.common_service.message.PaymentMessage;
 import com.taken_seat.common_service.message.PaymentRefundMessage;
 import com.taken_seat.common_service.message.QueueEnterMessage;
@@ -49,40 +50,49 @@ public class BookingKafkaProducer implements BookingProducer {
 	@Value("${kafka.topic.booking-updated}")
 	private String BOOKING_UPDATED_TOPIC;
 
+	@Value("${kafka.topic.booking-completed}")
+	private String BOOKING_COMPLETED_TOPIC;
+
 	@Override
-	public void sendPaymentRequest(PaymentMessage message) {
+	public void sendPaymentMessage(PaymentMessage message) {
 
 		kafkaTemplate.send(PAYMENT_REQUEST_TOPIC, message);
 	}
 
 	@Override
-	public void sendTicketRequest(TicketRequestMessage message) {
+	public void sendTicketRequestMessage(TicketRequestMessage message) {
 
 		kafkaTemplate.send(TICKET_REQUEST_TOPIC, message);
 	}
 
 	@Override
-	public void sendBenefitUsageRequest(UserBenefitMessage message) {
+	public void sendBenefitUsageMessage(UserBenefitMessage message) {
 
 		kafkaTemplate.send(BENEFIT_USAGE_REQUEST_TOPIC, message);
 	}
 
 	@Override
-	public void sendBenefitRefundRequest(UserBenefitMessage message) {
+	public void sendBenefitRefundMessage(UserBenefitMessage message) {
 
 		kafkaTemplate.send(BENEFIT_REFUND_REQUEST_TOPIC, message);
 	}
 
 	@Override
-	public void sendPaymentRefundRequest(PaymentRefundMessage message) {
+	public void sendPaymentRefundMessage(PaymentRefundMessage message) {
 
 		kafkaTemplate.send(PAYMENT_REFUND_REQUEST_TOPIC, message);
 	}
 
 	@Override
-	public void sendQueueEnterResponse(QueueEnterMessage message) {
+	public void sendQueueEnterMessage(QueueEnterMessage message) {
 
 		kafkaTemplate.send(QUEUE_RESPONSE_TOPIC, message);
+	}
+
+	@Override
+	public void sendBookingCompletedMessage(BookingCompletedMessage message) {
+
+		kafkaTemplate.send(BOOKING_COMPLETED_TOPIC, message);
 	}
 
 	@Override

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/repository/BookingCommandJpaRepository.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/repository/BookingCommandJpaRepository.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.taken_seat.booking_service.booking.domain.BookingCommand;
+import com.taken_seat.booking_service.booking.domain.BookingStatus;
 
 public interface BookingCommandJpaRepository extends JpaRepository<BookingCommand, UUID> {
 	boolean existsByUserIdAndPerformanceIdAndPerformanceScheduleIdAndScheduleSeatIdAndCanceledAtIsNullAndDeletedAtIsNull(
@@ -14,4 +15,6 @@ public interface BookingCommandJpaRepository extends JpaRepository<BookingComman
 	Optional<BookingCommand> findByIdAndUserId(UUID id, UUID userId);
 
 	Optional<BookingCommand> findByIdAndDeletedAtIsNull(UUID id);
+
+	int countByUserIdAndPerformanceIdAndBookingStatus(UUID userId, UUID performanceId, BookingStatus bookingStatus);
 }

--- a/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/repository/BookingCommandRepositoryImpl.java
+++ b/com.taken_seat.booking-service/src/main/java/com/taken_seat/booking_service/booking/infrastructure/repository/BookingCommandRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Repository;
 
 import com.taken_seat.booking_service.booking.domain.BookingCommand;
+import com.taken_seat.booking_service.booking.domain.BookingStatus;
 import com.taken_seat.booking_service.booking.domain.repository.BookingCommandRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -35,5 +36,12 @@ public class BookingCommandRepositoryImpl implements BookingCommandRepository {
 	@Override
 	public Optional<BookingCommand> findById(UUID id) {
 		return bookingCommandJpaRepository.findByIdAndDeletedAtIsNull(id);
+	}
+
+	@Override
+	public int countByUserIdAndPerformanceIdAndBookingStatus(UUID userId, UUID performanceId,
+		BookingStatus bookingStatus) {
+		return bookingCommandJpaRepository.countByUserIdAndPerformanceIdAndBookingStatus(userId, performanceId,
+			bookingStatus);
 	}
 }

--- a/com.taken_seat.booking-service/src/main/resources/application.yml
+++ b/com.taken_seat.booking-service/src/main/resources/application.yml
@@ -54,16 +54,17 @@ kafka:
     benefit-refund-response: benefit.refund.response
     benefit-usage-request: benefit.usage.request
     benefit-usage-response: benefit.usage.response
+    booking-completed: booking.completed.v1
+    booking-created: booking.created
+    booking-expire: booking.expire
+    booking-updated: booking.updated
     payment-refund-request: payment.refund.request
     payment-refund-response: payment.refund.response
     payment-request: payment.request
     payment-response: payment.response
-    ticket-request: ticket.request
     queue-request: waitingQueue.exit.request
     queue-response: waitingQueue.enter.request
-    booking-expire: booking.expire
-    booking-created: booking.created
-    booking-updated: booking.updated
+    ticket-request: ticket.request
   consumer:
     group-id:
       booking-command: booking-command

--- a/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/message/BookingCompletedMessage.java
+++ b/com.taken_seat.common-service/src/main/java/com/taken_seat/common_service/message/BookingCompletedMessage.java
@@ -1,4 +1,4 @@
-package com.taken_seat.performance_service.recommend.infrastructure.kafka.dto;
+package com.taken_seat.common_service.message;
 
 import java.util.UUID;
 

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/common/config/KafkaConsumerConfig.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/common/config/KafkaConsumerConfig.java
@@ -19,8 +19,8 @@ import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.util.backoff.FixedBackOff;
 
+import com.taken_seat.common_service.message.BookingCompletedMessage;
 import com.taken_seat.performance_service.performance.infrastructure.kafka.producer.SeatStatusChangedEvent;
-import com.taken_seat.performance_service.recommend.infrastructure.kafka.dto.BookingCompletedMessage;
 import com.taken_seat.performance_service.recommend.infrastructure.kafka.dto.RecommendRequestMessage;
 import com.taken_seat.performance_service.recommend.infrastructure.kafka.dto.UserSnapshotEvent;
 
@@ -130,7 +130,7 @@ public class KafkaConsumerConfig {
 			buildCommonConsumerProps("user-snapshot-group", type)
 		);
 	}
-	
+
 	@Bean
 	public ConcurrentKafkaListenerContainerFactory<String, UserSnapshotEvent>
 	userSnapshotListenerContainerFactory(

--- a/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/recommend/infrastructure/kafka/consumer/BookingCompletedListener.java
+++ b/com.taken_seat.performance-service/src/main/java/com/taken_seat/performance_service/recommend/infrastructure/kafka/consumer/BookingCompletedListener.java
@@ -3,9 +3,9 @@ package com.taken_seat.performance_service.recommend.infrastructure.kafka.consum
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
+import com.taken_seat.common_service.message.BookingCompletedMessage;
 import com.taken_seat.performance_service.recommend.application.command.RecommendRegisterCommand;
 import com.taken_seat.performance_service.recommend.application.service.RecommendMatrixService;
-import com.taken_seat.performance_service.recommend.infrastructure.kafka.dto.BookingCompletedMessage;
 import com.taken_seat.performance_service.recommend.infrastructure.redis.RecommendationCacheService;
 
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 개요
공연 도메인에 있던 BookingCompletedMessage 를 common - message 로 이동했습니다.

사용자가 예매를 결제 완료할 때마다 사용자가 해당 공연을 몇 번 구매했었는 지에 대한 정보를 공연 도메인에 전달합니다.

예매 도메인의 Kafka producer 메서드 이름을 일관적이게 변경했습니다.

## 작업 내용
### 변경 사항

### 변경 이유

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
#476 

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
