### PR TITLE
#471 <Review> 리뷰 변경 감지 기반 평점 캐싱 갱신 기능 구현

### DIFF
--- a/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/util/DataInitializer.java
+++ b/com.taken_seat.auth-service/src/main/java/com/taken_seat/auth_service/infrastructure/util/DataInitializer.java
@@ -1,48 +1,50 @@
 package com.taken_seat.auth_service.infrastructure.util;
 
-import lombok.RequiredArgsConstructor;
+import java.util.UUID;
+
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class DataInitializer implements CommandLineRunner {
 
-    private final JdbcTemplate jdbcTemplate;
-    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+	private final JdbcTemplate jdbcTemplate;
+	private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    // 고정된 created_by UUID
-    private static final UUID FIXED_CREATED_BY = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-000000000001");
+	// 고정된 created_by UUID
+	private static final UUID FIXED_CREATED_BY = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-000000000001");
 
-    @Override
-    public void run(String... args) throws Exception {
-        // 역할(Role)의 샘플 데이터
-        String[] roles = {"MANAGER", "CUSTOMER", "PRODUCER", "ADMIN"};
+	@Override
+	public void run(String... args) throws Exception {
+		// 역할(Role)의 샘플 데이터
+		String[] roles = {"MANAGER", "CUSTOMER", "PRODUCER", "ADMIN"};
 
-        // 100개의 사용자 데이터를 동적으로 삽입 (하지만 예측 가능한 값으로)
-        for (int i = 0; i < 10000; i++) {
-            // 예측 가능한 ID 생성 (인덱스 기반)
-            String uuidString = String.format("abcdef01-2345-6789-abcd-%012d", i);
-            UUID id = UUID.fromString(uuidString);
+		// 100개의 사용자 데이터를 동적으로 삽입 (하지만 예측 가능한 값으로)
+		for (int i = 0; i < 10000; i++) {
+			// 예측 가능한 ID 생성 (인덱스 기반)
+			String uuidString = String.format("abcdef01-2345-6789-abcd-%012d", i);
+			UUID id = UUID.fromString(uuidString);
 
-            String username = "user" + (i + 1);
-            String email = "user" + (i + 1) + "@example.com";
-            String phone = String.format("010-1234-%04d", i);
-            String password = bCryptPasswordEncoder.encode("password" + (i + 1) + "!");
-            String role = roles[i % roles.length];
-            UUID createdBy = FIXED_CREATED_BY; // 항상 고정된 UUID 사용
+			String username = "user" + (i + 1);
+			String email = "user" + (i + 1) + "@example.com";
+			String phone = String.format("010-1234-%04d", i);
+			String password = bCryptPasswordEncoder.encode("password" + (i + 1) + "!");
+			String role = roles[i % roles.length];
+			UUID createdBy = FIXED_CREATED_BY; // 항상 고정된 UUID 사용
 
-            // SQL 쿼리
-            String insertSql = "INSERT INTO p_user (id, username, email, phone, password, role, created_at, updated_at, created_by) " +
-                    "VALUES (UUID_TO_BIN(?), ?, ?, ?, ?, ?, NOW(), NOW(), UUID_TO_BIN(?))";
+			// SQL 쿼리
+			String insertSql =
+				"INSERT INTO p_user (id, username, email, phone, password, role, created_at, updated_at, created_by) " +
+					"VALUES (UUID_TO_BIN(?), ?, ?, ?, ?, ?, NOW(), NOW(), UUID_TO_BIN(?))";
 
-            // 데이터 삽입
-            jdbcTemplate.update(insertSql, id.toString(), username, email, phone, password, role, createdBy.toString());
-            System.out.println("Inserted user: " + username + " (ID: " + id + ")");
-        }
-    }
+			// 데이터 삽입
+			jdbcTemplate.update(insertSql, id.toString(), username, email, phone, password, role, createdBy.toString());
+			System.out.println("Inserted user: " + username + " (ID: " + id + ")");
+		}
+	}
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/scheduler/AvgRatingBulkScheduler.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/scheduler/AvgRatingBulkScheduler.java
@@ -26,9 +26,10 @@ public class AvgRatingBulkScheduler {
 	})
 	public void fetchPerformanceRatingStatsBulk() {
 		log.info("[Review][Scheduler] 공연 별 평균 평점 계산 및 캐시 반영 시작");
+
 		try {
 			long start = System.currentTimeMillis();
-			redisRatingRepository.setAvgRatingBulk();
+			redisRatingRepository.setAvgRatingForChangedPerformances();
 			long end = System.currentTimeMillis();
 			System.out.println("평점 대량 저장 실행 시간: " + (end - start) + "ms");
 			log.info("[Review][Scheduler] 평균 평점 계산 및 캐시 반영 완료");

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/scheduler/AvgRatingBulkScheduler.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/scheduler/AvgRatingBulkScheduler.java
@@ -6,7 +6,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.taken_seat.review_service.domain.repository.RedisRatingRepository;
-import com.taken_seat.review_service.domain.repository.ReviewRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,10 +16,10 @@ import lombok.extern.slf4j.Slf4j;
 public class AvgRatingBulkScheduler {
 
 	private final RedisRatingRepository redisRatingRepository;
-	private final ReviewRepository reviewRepository;
 
 	// 한시간 마다 리뷰 평점을 업데이트
-	@Scheduled(cron = "0 0 * * * ?")
+	// @Scheduled(cron = "0 0 * * * ?")
+	@Scheduled(cron = "0 */2 * * * ?")
 	@Caching(evict = {
 		@CacheEvict(cacheNames = "reviewCache", allEntries = true),
 		@CacheEvict(cacheNames = "reviewSearchCache", allEntries = true)

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/scheduler/AvgRatingBulkScheduler.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/scheduler/AvgRatingBulkScheduler.java
@@ -18,8 +18,7 @@ public class AvgRatingBulkScheduler {
 	private final RedisRatingRepository redisRatingRepository;
 
 	// 한시간 마다 리뷰 평점을 업데이트
-	// @Scheduled(cron = "0 0 * * * ?")
-	@Scheduled(cron = "0 */2 * * * ?")
+	@Scheduled(cron = "0 0 * * * ?")
 	@Caching(evict = {
 		@CacheEvict(cacheNames = "reviewCache", allEntries = true),
 		@CacheEvict(cacheNames = "reviewSearchCache", allEntries = true)
@@ -28,10 +27,7 @@ public class AvgRatingBulkScheduler {
 		log.info("[Review][Scheduler] 공연 별 평균 평점 계산 및 캐시 반영 시작");
 
 		try {
-			long start = System.currentTimeMillis();
 			redisRatingRepository.setAvgRatingForChangedPerformances();
-			long end = System.currentTimeMillis();
-			System.out.println("평점 대량 저장 실행 시간: " + (end - start) + "ms");
 			log.info("[Review][Scheduler] 평균 평점 계산 및 캐시 반영 완료");
 		} catch (Exception e) {
 			log.error("[Review][Scheduler] 평균 평점 계산 중 예외 발생: {}", e.getMessage(), e);

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/scheduler/AvgRatingBulkScheduler.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/scheduler/AvgRatingBulkScheduler.java
@@ -27,7 +27,10 @@ public class AvgRatingBulkScheduler {
 	public void fetchPerformanceRatingStatsBulk() {
 		log.info("[Review][Scheduler] 공연 별 평균 평점 계산 및 캐시 반영 시작");
 		try {
+			long start = System.currentTimeMillis();
 			redisRatingRepository.setAvgRatingBulk();
+			long end = System.currentTimeMillis();
+			System.out.println("평점 대량 저장 실행 시간: " + (end - start) + "ms");
 			log.info("[Review][Scheduler] 평균 평점 계산 및 캐시 반영 완료");
 		} catch (Exception e) {
 			log.error("[Review][Scheduler] 평균 평점 계산 중 예외 발생: {}", e.getMessage(), e);

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewChangeMaker.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewChangeMaker.java
@@ -1,0 +1,7 @@
+package com.taken_seat.review_service.application.service;
+
+import java.util.UUID;
+
+public interface ReviewChangeMaker {
+	void markPerformanceChanged(UUID performanceId);
+}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewChangeMaker.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewChangeMaker.java
@@ -1,7 +1,12 @@
 package com.taken_seat.review_service.application.service;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ReviewChangeMaker {
 	void markPerformanceChanged(UUID performanceId);
+
+	List<UUID> getChangedPerformanceIds();
+
+	void clearChangedPerformanceIds();
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewServiceImpl.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewServiceImpl.java
@@ -116,9 +116,13 @@ public class ReviewServiceImpl implements ReviewService {
 
 		validateAccessAuthority(review, reviewDto);
 
+		short originRating = review.getRating();
+		short newRating = reviewDto.getRating();
+
 		review.update(reviewDto);
 
-		reviewChangeMaker.markPerformanceChanged(review.getPerformanceId());
+		if (originRating != newRating)
+			reviewChangeMaker.markPerformanceChanged(review.getPerformanceId());
 
 		return reviewMapper.toResponse(review);
 	}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewServiceImpl.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/application/service/ReviewServiceImpl.java
@@ -38,6 +38,7 @@ public class ReviewServiceImpl implements ReviewService {
 	private final RedisRatingRepository redisRatingRepository;
 	private final ReviewClient reviewClient;
 	private final ReviewMapper reviewMapper;
+	private final ReviewChangeMaker reviewChangeMaker;
 
 	@Override
 	@CachePut(cacheNames = "reviewCache", key = "#result.id")
@@ -74,6 +75,8 @@ public class ReviewServiceImpl implements ReviewService {
 		// 4. 리뷰 생성 및 저장
 		Review review = Review.create(reviewDto);
 		reviewRepository.save(review);
+
+		reviewChangeMaker.markPerformanceChanged(review.getPerformanceId());
 
 		return reviewMapper.toResponse(review);
 	}
@@ -115,6 +118,8 @@ public class ReviewServiceImpl implements ReviewService {
 
 		review.update(reviewDto);
 
+		reviewChangeMaker.markPerformanceChanged(review.getPerformanceId());
+
 		return reviewMapper.toResponse(review);
 	}
 
@@ -131,6 +136,9 @@ public class ReviewServiceImpl implements ReviewService {
 		validateAccessAuthority(review, reviewDto);
 
 		review.delete(reviewDto.getUserId());
+
+		reviewChangeMaker.markPerformanceChanged(review.getPerformanceId());
+
 	}
 
 	private void validateAccessAuthority(Review review, ReviewDto reviewDto) {

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/repository/RedisRatingRepository.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/repository/RedisRatingRepository.java
@@ -9,5 +9,5 @@ public interface RedisRatingRepository {
 
 	Double getAvgRating(UUID performanceId);
 
-	void setAvgRatingBulk();
+	void setAvgRatingForChangedPerformances();
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/repository/ReviewRepository.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/domain/repository/ReviewRepository.java
@@ -22,5 +22,5 @@ public interface ReviewRepository {
 
 	Map<String, Object> fetchAvgRatingAndReviewCountByPerformanceId(UUID performanceId);
 	
-	List<Map<String, Object>> fetchPerformanceRatingStatsBulk();
+	List<Map<String, Object>> fetchAvgRatingAndReviewCountByPerformanceIds(List<UUID> performanceIds);
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/client/dto/PerformanceEndTimeDto.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/client/dto/PerformanceEndTimeDto.java
@@ -2,9 +2,6 @@ package com.taken_seat.review_service.infrastructure.client.dto;
 
 import java.time.LocalDateTime;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-
 public record PerformanceEndTimeDto(
-	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	LocalDateTime endAt) {
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/redis/service/ReviewChangeMakerImpl.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/redis/service/ReviewChangeMakerImpl.java
@@ -1,6 +1,9 @@
 package com.taken_seat.review_service.infrastructure.redis.service;
 
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
@@ -27,5 +30,23 @@ public class ReviewChangeMakerImpl implements ReviewChangeMaker {
 		} catch (Exception e) {
 			throw new ReviewException(ResponseCode.ILLEGAL_ARGUMENT);
 		}
+	}
+
+	@Override
+	public List<UUID> getChangedPerformanceIds() {
+		Set<String> changedIds = redisTemplate.opsForSet().members(PERFORMANCE_ID_SET_KEY);
+		if (changedIds == null || changedIds.isEmpty()) {
+			log.info("[Review] 변경된 공연 없음. Redis 업데이트 생략");
+			return List.of(); // 빈 리스트 반환
+		}
+
+		return changedIds.stream()
+			.map(UUID::fromString)
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public void clearChangedPerformanceIds() {
+		redisTemplate.delete(PERFORMANCE_ID_SET_KEY);
 	}
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/redis/service/ReviewChangeMakerImpl.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/redis/service/ReviewChangeMakerImpl.java
@@ -1,5 +1,6 @@
 package com.taken_seat.review_service.infrastructure.redis.service;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -27,6 +28,8 @@ public class ReviewChangeMakerImpl implements ReviewChangeMaker {
 	public void markPerformanceChanged(UUID performanceId) {
 		try {
 			redisTemplate.opsForSet().add(PERFORMANCE_ID_SET_KEY, performanceId.toString());
+
+			redisTemplate.expire(PERFORMANCE_ID_SET_KEY, Duration.ofHours(1));
 		} catch (Exception e) {
 			throw new ReviewException(ResponseCode.ILLEGAL_ARGUMENT);
 		}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/redis/service/ReviewChangeMakerImpl.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/redis/service/ReviewChangeMakerImpl.java
@@ -1,0 +1,31 @@
+package com.taken_seat.review_service.infrastructure.redis.service;
+
+import java.util.UUID;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.taken_seat.common_service.exception.customException.ReviewException;
+import com.taken_seat.common_service.exception.enums.ResponseCode;
+import com.taken_seat.review_service.application.service.ReviewChangeMaker;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class ReviewChangeMakerImpl implements ReviewChangeMaker {
+
+	private final String PERFORMANCE_ID_SET_KEY = "review:changed:performanceId:set";
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Override
+	public void markPerformanceChanged(UUID performanceId) {
+		try {
+			redisTemplate.opsForSet().add(PERFORMANCE_ID_SET_KEY, performanceId.toString());
+		} catch (Exception e) {
+			throw new ReviewException(ResponseCode.ILLEGAL_ARGUMENT);
+		}
+	}
+}

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/redis/service/ReviewLikeServiceImpl.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/redis/service/ReviewLikeServiceImpl.java
@@ -1,4 +1,4 @@
-package com.taken_seat.review_service.application.service;
+package com.taken_seat.review_service.infrastructure.redis.service;
 
 import java.util.HashMap;
 import java.util.List;
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.taken_seat.common_service.exception.customException.ReviewException;
 import com.taken_seat.common_service.exception.enums.ResponseCode;
 import com.taken_seat.review_service.application.dto.service.ReviewDto;
+import com.taken_seat.review_service.application.service.ReviewLikeService;
 import com.taken_seat.review_service.domain.model.Review;
 import com.taken_seat.review_service.domain.model.ReviewLike;
 import com.taken_seat.review_service.domain.repository.ReviewLikeRepository;

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/repository/ReviewJpaRepository.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/repository/ReviewJpaRepository.java
@@ -20,7 +20,7 @@ public interface ReviewJpaRepository extends JpaRepository<Review, UUID> {
 	<S extends Review> List<S> saveAllAndFlush(Iterable<S> entities);
 
 	@Query(value =
-		"SELECT r.performance_id AS performanceId, AVG(r.rating) AS avgRating, COUNT(r.id) AS reviewCount "
+		"SELECT r.performance_id AS performanceId,ROUND(AVG(r.rating), 2) AS avgRating, COUNT(r.id) AS reviewCount "
 			+ "FROM p_review r "
 			+ "WHERE r.performance_id = :performanceId AND r.deleted_at IS NULL", nativeQuery = true)
 	Map<String, Object> fetchAvgRatingAndReviewCountByPerformanceId(UUID performanceId);

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/repository/ReviewJpaRepository.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/repository/ReviewJpaRepository.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.taken_seat.review_service.domain.model.Review;
 
@@ -31,5 +32,17 @@ public interface ReviewJpaRepository extends JpaRepository<Review, UUID> {
 			+ "GROUP BY r.performance_id",
 		nativeQuery = true)
 	List<Map<String, Object>> fetchPerformanceRatingStatsBulk();
+
+	@Query(value = """
+		    SELECT
+		        r.performance_id,
+		        ROUND(AVG(r.rating), 2) AS avgRating,
+		        COUNT(*) AS reviewCount
+		    FROM p_review r
+		    WHERE r.performance_id IN :performanceIds
+		    GROUP BY r.performance_id
+		""", nativeQuery = true)
+	List<Map<String, Object>> fetchAvgRatingAndReviewCountByPerformanceIds(
+		@Param("performanceIds") List<UUID> performanceIds);
 
 }

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/repository/ReviewJpaRepository.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/repository/ReviewJpaRepository.java
@@ -25,14 +25,6 @@ public interface ReviewJpaRepository extends JpaRepository<Review, UUID> {
 			+ "WHERE r.performance_id = :performanceId AND r.deleted_at IS NULL", nativeQuery = true)
 	Map<String, Object> fetchAvgRatingAndReviewCountByPerformanceId(UUID performanceId);
 
-	@Query(value =
-		"SELECT r.performance_id AS performanceId, AVG(r.rating) AS avgRating, COUNT(r.id) AS reviewCount "
-			+ "FROM p_review r "
-			+ "WHERE r.deleted_at IS NULL "
-			+ "GROUP BY r.performance_id",
-		nativeQuery = true)
-	List<Map<String, Object>> fetchPerformanceRatingStatsBulk();
-
 	@Query(value = """
 		    SELECT
 		        r.performance_id,

--- a/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/repository/ReviewRepositoryImpl.java
+++ b/com.taken_seat.review-service/src/main/java/com/taken_seat/review_service/infrastructure/repository/ReviewRepositoryImpl.java
@@ -44,7 +44,7 @@ public class ReviewRepositoryImpl implements ReviewRepository {
 	}
 
 	@Override
-	public List<Map<String, Object>> fetchPerformanceRatingStatsBulk() {
-		return reviewJpaRepository.fetchPerformanceRatingStatsBulk();
+	public List<Map<String, Object>> fetchAvgRatingAndReviewCountByPerformanceIds(List<UUID> performanceIds) {
+		return reviewJpaRepository.fetchAvgRatingAndReviewCountByPerformanceIds(performanceIds);
 	}
 }

--- a/com.taken_seat.review-service/src/test/java/com/taken_seat/review_service/unit/ReviewLikeServiceTest.java
+++ b/com.taken_seat.review-service/src/test/java/com/taken_seat/review_service/unit/ReviewLikeServiceTest.java
@@ -17,12 +17,12 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 import com.taken_seat.common_service.dto.AuthenticatedUser;
 import com.taken_seat.review_service.application.dto.service.ReviewDto;
-import com.taken_seat.review_service.application.service.ReviewLikeServiceImpl;
 import com.taken_seat.review_service.domain.model.Review;
 import com.taken_seat.review_service.domain.model.ReviewLike;
 import com.taken_seat.review_service.domain.repository.ReviewLikeRepository;
 import com.taken_seat.review_service.domain.repository.ReviewRepository;
 import com.taken_seat.review_service.infrastructure.mapper.ReviewMapper;
+import com.taken_seat.review_service.infrastructure.redis.service.ReviewLikeServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
 public class ReviewLikeServiceTest {

--- a/com.taken_seat.review-service/src/test/java/com/taken_seat/review_service/unit/ReviewLikeServiceTest.java
+++ b/com.taken_seat.review-service/src/test/java/com/taken_seat/review_service/unit/ReviewLikeServiceTest.java
@@ -15,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 
-import com.taken_seat.common_service.dto.AuthenticatedUser;
 import com.taken_seat.review_service.application.dto.service.ReviewDto;
 import com.taken_seat.review_service.domain.model.Review;
 import com.taken_seat.review_service.domain.model.ReviewLike;
@@ -47,14 +46,12 @@ public class ReviewLikeServiceTest {
 
 	private UUID reviewId;
 	private UUID userId;
-	private AuthenticatedUser user;
 	private ReviewDto reviewDto;
 
 	@BeforeEach
 	void setUp() {
 		reviewId = UUID.randomUUID();
 		userId = UUID.randomUUID();
-		user = new AuthenticatedUser(userId, "user@example.com", "MASTER");
 
 		reviewDto = ReviewDto.builder()
 			.userId(userId)

--- a/com.taken_seat.review-service/src/test/java/com/taken_seat/review_service/unit/ReviewServicesTest.java
+++ b/com.taken_seat.review-service/src/test/java/com/taken_seat/review_service/unit/ReviewServicesTest.java
@@ -27,6 +27,7 @@ import com.taken_seat.review_service.application.dto.controller.response.PageRev
 import com.taken_seat.review_service.application.dto.controller.response.ReviewDetailResDto;
 import com.taken_seat.review_service.application.dto.service.ReviewDto;
 import com.taken_seat.review_service.application.dto.service.ReviewSearchDto;
+import com.taken_seat.review_service.application.service.ReviewChangeMaker;
 import com.taken_seat.review_service.application.service.ReviewServiceImpl;
 import com.taken_seat.review_service.domain.model.Review;
 import com.taken_seat.review_service.domain.repository.CustomReviewQuerydslRepository;
@@ -53,6 +54,9 @@ public class ReviewServicesTest {
 
 	@Mock
 	private RedisRatingRepository redisRatingRepository;
+
+	@Mock
+	private ReviewChangeMaker reviewChangeMaker;
 
 	@InjectMocks
 	private ReviewServiceImpl reviewServices;
@@ -156,6 +160,8 @@ public class ReviewServicesTest {
 		ReviewDetailResDto result = reviewServices.registerReview(testReviewDto);
 
 		// Then
+		verify(reviewChangeMaker).markPerformanceChanged(testPerformanceId);
+
 		assertNotNull(result);
 		assertEquals("testTitle", result.getTitle());
 		assertEquals("testContent", result.getContent());
@@ -369,6 +375,7 @@ public class ReviewServicesTest {
 		ReviewDetailResDto result = reviewServices.updateReview(testReviewDto);
 
 		// Then
+		verify(reviewChangeMaker).markPerformanceChanged(testPerformanceId);
 		assertNotNull(result);
 		assertEquals("updateTitle", result.getTitle());
 		assertEquals("updateContent", result.getContent());
@@ -446,6 +453,7 @@ public class ReviewServicesTest {
 		assertDoesNotThrow(() -> reviewServices.deleteReview(testReviewDto));
 
 		// Then
+		verify(reviewChangeMaker).markPerformanceChanged(testPerformanceId);
 		assertNotNull(testReview.getDeletedAt());
 	}
 


### PR DESCRIPTION
## 개요
리뷰 평점 갱신 기능에 리뷰 변경이 된것들만 갱신되게 변경했습니다.

## 작업 내용
### 변경 사항
- 기존 구조는 전체 조회 후 모든 공연에 대한 리뷰 평점 갱신
- 조회 범위도 너무 크고 성능 이슈가 있어 구조 변경
- 리뷰가 갱신될 때 마다 해당 리뷰의 공연 id를 캐싱해 저장
- 스케줄러로 평점 갱신이 이뤄질 때 마다 캐싱에 저장된 공연 id만 가져와 평점 갱신

### 변경 이유
- 자원소모가 너무 심하고 조회가 너무 느림

### 추가 설명

## 리뷰 요구사항

#### 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
